### PR TITLE
feat(rules): rule engine + PS001-PS003, PS030-PS032 (M2 part 1)

### DIFF
--- a/src/core/finding.ts
+++ b/src/core/finding.ts
@@ -1,0 +1,44 @@
+/**
+ * Finding construction helpers shared by all rules.
+ */
+import type { ShellTarget } from '../parser/ir';
+import type { Confidence, Finding, FixCandidate, RuleContext, RuleMetadata, Severity } from '../rules/types';
+import { intersectTargets } from './targets';
+
+export interface FindingOpts {
+  message: string;
+  span: [number, number];
+  fix?: FixCandidate;
+  severity?: Severity;
+  confidence?: Confidence;
+  affectedTargets?: readonly ShellTarget[];
+}
+
+/**
+ * Build a finding, dropping it when none of its affected shells are active.
+ * Rules never need to filter targets themselves.
+ */
+export function makeFinding(
+  rule: Pick<RuleMetadata, 'id' | 'severity' | 'confidence' | 'affectedTargets'>,
+  ctx: RuleContext,
+  opts: FindingOpts,
+): Finding | null {
+  const affected = intersectTargets(opts.affectedTargets ?? rule.affectedTargets, ctx.targets);
+  if (affected.length === 0) return null;
+  return {
+    ruleId: rule.id,
+    scriptName: ctx.scriptName,
+    packagePath: ctx.packagePath,
+    span: opts.span,
+    severity: opts.severity ?? rule.severity,
+    confidence: opts.confidence ?? rule.confidence,
+    affectedTargets: affected,
+    message: opts.message,
+    fix: opts.fix,
+  };
+}
+
+/** Sort findings by span start, then rule id, for deterministic output. */
+export function sortFindings(findings: Finding[]): Finding[] {
+  return [...findings].sort((a, b) => a.span[0] - b.span[0] || a.ruleId.localeCompare(b.ruleId));
+}

--- a/src/core/finding.ts
+++ b/src/core/finding.ts
@@ -2,7 +2,14 @@
  * Finding construction helpers shared by all rules.
  */
 import type { ShellTarget } from '../parser/ir';
-import type { Confidence, Finding, FixCandidate, RuleContext, RuleMetadata, Severity } from '../rules/types';
+import type {
+  Confidence,
+  Finding,
+  FixCandidate,
+  RuleContext,
+  RuleMetadata,
+  Severity,
+} from '../rules/types';
 import { intersectTargets } from './targets';
 
 export interface FindingOpts {

--- a/src/core/targets.ts
+++ b/src/core/targets.ts
@@ -1,0 +1,31 @@
+/**
+ * Target shell resolution: CLI `--target`, config `targets`, and the default
+ * matrix (npm's actual script shells: `sh` on macOS/Linux, `cmd.exe` on
+ * Windows). PowerShell joins only when explicitly declared.
+ */
+import type { ShellTarget } from '../parser/ir';
+
+export const ALL_TARGETS: readonly ShellTarget[] = ['posix-sh', 'cmd', 'powershell'];
+
+/** npm's default script shells on the platforms contributors actually use. */
+export const DEFAULT_TARGETS: readonly ShellTarget[] = ['posix-sh', 'cmd'];
+
+export function parseTargets(value: string | undefined): ShellTarget[] | null {
+  if (value === undefined || value.trim() === '') return null;
+  const targets: ShellTarget[] = [];
+  for (const part of value.split(',')) {
+    const t = part.trim().toLowerCase();
+    if (t === '') continue;
+    const match = ALL_TARGETS.find((c) => c === t);
+    if (match === undefined) return null; // invalid target: config error territory
+    if (!targets.includes(match)) targets.push(match);
+  }
+  return targets.length > 0 ? targets : null;
+}
+
+export function intersectTargets(
+  affected: readonly ShellTarget[],
+  active: readonly ShellTarget[],
+): ShellTarget[] {
+  return affected.filter((t) => active.includes(t));
+}

--- a/src/rules/PS001.ts
+++ b/src/rules/PS001.ts
@@ -1,0 +1,60 @@
+/**
+ * PS001 — POSIX_INLINE_ENV: `FOO=bar command` assignments are POSIX-shell
+ * syntax with no equivalent in cmd.exe.
+ */
+import { commandName } from '../parser/ir';
+import { makeFinding } from '../core/finding';
+import { commandsOf, PORTABILITY_TOOLS } from './util';
+import type { Finding, RuleContext, RuleModule } from './types';
+
+export const PS001: RuleModule = {
+  id: 'PS001',
+  title: 'POSIX_INLINE_ENV',
+  summary: 'Inline environment assignments (`FOO=bar cmd`) do not work in cmd.exe npm scripts.',
+  severity: 'error',
+  confidence: 'high',
+  affectedTargets: ['cmd'],
+  badExamples: ['NODE_ENV=production vite build', 'A=1 B=2 node app.js', 'GIT_AUTHOR_NAME=x npm publish'],
+  goodExamples: ['cross-env NODE_ENV=production vite build', 'node app.js', 'vite build'],
+  falsePositiveNotes:
+    'Not reported when the command is already cross-env/cross-env-shell (the portability layer exists), or inside explicit shell wrappers.',
+  fixSafety: 'conditional',
+  provenance: [
+    {
+      source: 'https://www.gnu.org/software/bash/manual/html_node/Environment.html',
+      claim: 'Assignment prefixes are a POSIX shell feature that applies env vars to one command.',
+    },
+    {
+      source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/set_1',
+      claim: 'cmd.exe has no per-command assignment; `set` persists in the session and `FOO=bar cmd` would try to run a program literally named FOO=bar.',
+    },
+  ],
+  check(ir, ctx: RuleContext): Finding[] {
+    const findings: Finding[] = [];
+    for (const cmd of commandsOf(ir)) {
+      if (cmd.leadingEnv.length === 0) continue;
+      const name = commandName(cmd);
+      if (name !== null && PORTABILITY_TOOLS.has(name.toLowerCase())) continue;
+      const first = cmd.leadingEnv[0];
+      if (first === undefined) continue;
+      const hasCrossEnv = ctx.dependencies.has('cross-env');
+      const finding = makeFinding(this, ctx, {
+        message: `POSIX inline env assignment \`${first.name}=${first.value}\` is not portable to cmd.exe`,
+        span: first.span,
+        fix: {
+          ruleId: this.id,
+          safety: hasCrossEnv ? 'safe' : 'conditional',
+          description: hasCrossEnv
+            ? `rewrite as \`${first.name}=${first.value} …\` under cross-env (cross-env is already a dependency)`
+            : 'add cross-env as a devDependency, then wrap the assignment',
+          requiresDependency: hasCrossEnv ? undefined : 'cross-env',
+          replacement: hasCrossEnv
+            ? { span: [first.span[0], first.span[0]], text: 'cross-env ' }
+            : undefined,
+        },
+      });
+      if (finding !== null) findings.push(finding);
+    }
+    return findings;
+  },
+};

--- a/src/rules/PS001.ts
+++ b/src/rules/PS001.ts
@@ -2,10 +2,11 @@
  * PS001 — POSIX_INLINE_ENV: `FOO=bar command` assignments are POSIX-shell
  * syntax with no equivalent in cmd.exe.
  */
-import { commandName } from '../parser/ir';
+
 import { makeFinding } from '../core/finding';
-import { commandsOf, PORTABILITY_TOOLS } from './util';
+import { commandName } from '../parser/ir';
 import type { Finding, RuleContext, RuleModule } from './types';
+import { commandsOf, PORTABILITY_TOOLS } from './util';
 
 export const PS001: RuleModule = {
   id: 'PS001',
@@ -14,7 +15,11 @@ export const PS001: RuleModule = {
   severity: 'error',
   confidence: 'high',
   affectedTargets: ['cmd'],
-  badExamples: ['NODE_ENV=production vite build', 'A=1 B=2 node app.js', 'GIT_AUTHOR_NAME=x npm publish'],
+  badExamples: [
+    'NODE_ENV=production vite build',
+    'A=1 B=2 node app.js',
+    'GIT_AUTHOR_NAME=x npm publish',
+  ],
   goodExamples: ['cross-env NODE_ENV=production vite build', 'node app.js', 'vite build'],
   falsePositiveNotes:
     'Not reported when the command is already cross-env/cross-env-shell (the portability layer exists), or inside explicit shell wrappers.',
@@ -25,8 +30,10 @@ export const PS001: RuleModule = {
       claim: 'Assignment prefixes are a POSIX shell feature that applies env vars to one command.',
     },
     {
-      source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/set_1',
-      claim: 'cmd.exe has no per-command assignment; `set` persists in the session and `FOO=bar cmd` would try to run a program literally named FOO=bar.',
+      source:
+        'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/set_1',
+      claim:
+        'cmd.exe has no per-command assignment; `set` persists in the session and `FOO=bar cmd` would try to run a program literally named FOO=bar.',
     },
   ],
   check(ir, ctx: RuleContext): Finding[] {

--- a/src/rules/PS002.ts
+++ b/src/rules/PS002.ts
@@ -3,15 +3,16 @@
  * no-op assignment in POSIX sh (`set` only manages shell options there).
  */
 import { makeFinding } from '../core/finding';
-import { commandsOf, isCommand } from './util';
 import type { Finding, RuleContext, RuleModule } from './types';
+import { commandsOf, isCommand } from './util';
 
 const CMD_SET_RE = /^[A-Za-z_][A-Za-z0-9_]*=/;
 
 export const PS002: RuleModule = {
   id: 'PS002',
   title: 'CMD_SET_ENV',
-  summary: '`set FOO=bar&& …` sets the variable only for cmd.exe; POSIX sh ignores it as an assignment.',
+  summary:
+    '`set FOO=bar&& …` sets the variable only for cmd.exe; POSIX sh ignores it as an assignment.',
   severity: 'warn',
   confidence: 'high',
   affectedTargets: ['posix-sh'],
@@ -22,12 +23,15 @@ export const PS002: RuleModule = {
   fixSafety: 'conditional',
   provenance: [
     {
-      source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/set_1',
-      claim: 'cmd.exe `set VAR=value` defines the variable in the session; `&&` then runs the next command with it set.',
+      source:
+        'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/set_1',
+      claim:
+        'cmd.exe `set VAR=value` defines the variable in the session; `&&` then runs the next command with it set.',
     },
     {
       source: 'https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#set',
-      claim: 'POSIX `set` changes shell options / positional parameters — `set FOO=bar` never exports an environment variable.',
+      claim:
+        'POSIX `set` changes shell options / positional parameters — `set FOO=bar` never exports an environment variable.',
     },
   ],
   check(ir, ctx: RuleContext): Finding[] {
@@ -42,7 +46,8 @@ export const PS002: RuleModule = {
         fix: {
           ruleId: this.id,
           safety: 'conditional',
-          description: 'use cross-env for per-command env vars, or restructure to avoid session state',
+          description:
+            'use cross-env for per-command env vars, or restructure to avoid session state',
           requiresDependency: 'cross-env',
         },
       });

--- a/src/rules/PS002.ts
+++ b/src/rules/PS002.ts
@@ -1,0 +1,53 @@
+/**
+ * PS002 — CMD_SET_ENV: `set FOO=bar&& cmd` persists env in cmd.exe but is a
+ * no-op assignment in POSIX sh (`set` only manages shell options there).
+ */
+import { makeFinding } from '../core/finding';
+import { commandsOf, isCommand } from './util';
+import type { Finding, RuleContext, RuleModule } from './types';
+
+const CMD_SET_RE = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+export const PS002: RuleModule = {
+  id: 'PS002',
+  title: 'CMD_SET_ENV',
+  summary: '`set FOO=bar&& …` sets the variable only for cmd.exe; POSIX sh ignores it as an assignment.',
+  severity: 'warn',
+  confidence: 'high',
+  affectedTargets: ['posix-sh'],
+  badExamples: ['set NODE_ENV=production&& node app.js', 'set FOO=bar&& vite build'],
+  goodExamples: ['cross-env NODE_ENV=production node app.js', 'node app.js'],
+  falsePositiveNotes:
+    'Only fires when the argument looks like NAME=VALUE. POSIX `set` option forms (`set -e`, `set -o pipefail`) are not reported by this rule.',
+  fixSafety: 'conditional',
+  provenance: [
+    {
+      source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/set_1',
+      claim: 'cmd.exe `set VAR=value` defines the variable in the session; `&&` then runs the next command with it set.',
+    },
+    {
+      source: 'https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#set',
+      claim: 'POSIX `set` changes shell options / positional parameters — `set FOO=bar` never exports an environment variable.',
+    },
+  ],
+  check(ir, ctx: RuleContext): Finding[] {
+    const findings: Finding[] = [];
+    for (const cmd of commandsOf(ir)) {
+      if (!isCommand(cmd, 'set')) continue;
+      const assignment = cmd.argv[1];
+      if (assignment === undefined || !CMD_SET_RE.test(assignment.value)) continue;
+      const finding = makeFinding(this, ctx, {
+        message: `\`set ${assignment.value}\` only sets the variable under cmd.exe; POSIX sh treats it as a positional parameter`,
+        span: assignment.span,
+        fix: {
+          ruleId: this.id,
+          safety: 'conditional',
+          description: 'use cross-env for per-command env vars, or restructure to avoid session state',
+          requiresDependency: 'cross-env',
+        },
+      });
+      if (finding !== null) findings.push(finding);
+    }
+    return findings;
+  },
+};

--- a/src/rules/PS003.ts
+++ b/src/rules/PS003.ts
@@ -2,26 +2,30 @@
  * PS003 — POWERSHELL_ENV: `$env:FOO='bar'` is PowerShell-specific syntax.
  */
 import { makeFinding } from '../core/finding';
-import { commandsOf } from './util';
 import type { Finding, RuleContext, RuleModule } from './types';
+import { commandsOf } from './util';
 
 const PS_ENV_RE = /^\$env:[A-Za-z_][A-Za-z0-9_]*\s*=/;
 
 export const PS003: RuleModule = {
   id: 'PS003',
   title: 'POWERSHELL_ENV',
-  summary: "`$env:NAME=…` assignment syntax exists only in PowerShell.",
+  summary: '`$env:NAME=…` assignment syntax exists only in PowerShell.',
   severity: 'warn',
   confidence: 'high',
   affectedTargets: ['posix-sh', 'cmd'],
   badExamples: ["$env:NODE_ENV='production'; node app.js", "$env:PATH='…'; npm test"],
-  goodExamples: ['cross-env NODE_ENV=production node app.js', 'powershell -Command "$env:X=1; node app.js"'],
+  goodExamples: [
+    'cross-env NODE_ENV=production node app.js',
+    'powershell -Command "$env:X=1; node app.js"',
+  ],
   falsePositiveNotes:
     'Not reported inside explicit powershell/pwsh wrappers (the dependency itself is reported by PS032 instead).',
   fixSafety: 'conditional',
   provenance: [
     {
-      source: 'https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_Environment_Variables',
+      source:
+        'https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_Environment_Variables',
       claim: '$env:NAME is the PowerShell provider syntax for environment variables.',
     },
     {

--- a/src/rules/PS003.ts
+++ b/src/rules/PS003.ts
@@ -1,0 +1,53 @@
+/**
+ * PS003 — POWERSHELL_ENV: `$env:FOO='bar'` is PowerShell-specific syntax.
+ */
+import { makeFinding } from '../core/finding';
+import { commandsOf } from './util';
+import type { Finding, RuleContext, RuleModule } from './types';
+
+const PS_ENV_RE = /^\$env:[A-Za-z_][A-Za-z0-9_]*\s*=/;
+
+export const PS003: RuleModule = {
+  id: 'PS003',
+  title: 'POWERSHELL_ENV',
+  summary: "`$env:NAME=…` assignment syntax exists only in PowerShell.",
+  severity: 'warn',
+  confidence: 'high',
+  affectedTargets: ['posix-sh', 'cmd'],
+  badExamples: ["$env:NODE_ENV='production'; node app.js", "$env:PATH='…'; npm test"],
+  goodExamples: ['cross-env NODE_ENV=production node app.js', 'powershell -Command "$env:X=1; node app.js"'],
+  falsePositiveNotes:
+    'Not reported inside explicit powershell/pwsh wrappers (the dependency itself is reported by PS032 instead).',
+  fixSafety: 'conditional',
+  provenance: [
+    {
+      source: 'https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_Environment_Variables',
+      claim: '$env:NAME is the PowerShell provider syntax for environment variables.',
+    },
+    {
+      source: 'https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html',
+      claim: 'POSIX sh and cmd.exe have no $env: namespace; the text is passed through literally.',
+    },
+  ],
+  check(ir, ctx: RuleContext): Finding[] {
+    const findings: Finding[] = [];
+    for (const cmd of commandsOf(ir)) {
+      if (cmd.wrapper?.shell === 'powershell') continue;
+      for (const tok of cmd.argv) {
+        if (!PS_ENV_RE.test(tok.value)) continue;
+        const finding = makeFinding(this, ctx, {
+          message: `\`${tok.raw.split('=')[0]}=…\` is PowerShell-only env syntax`,
+          span: tok.span,
+          fix: {
+            ruleId: this.id,
+            safety: 'conditional',
+            description: 'use cross-env, or keep the syntax inside an explicit powershell wrapper',
+            requiresDependency: 'cross-env',
+          },
+        });
+        if (finding !== null) findings.push(finding);
+      }
+    }
+    return findings;
+  },
+};

--- a/src/rules/PS030.ts
+++ b/src/rules/PS030.ts
@@ -1,0 +1,40 @@
+/**
+ * PS030 — EXPLICIT_BASH: scripts invoking bash/sh/zsh depend on a shell that
+ * default Windows environments do not have.
+ */
+import { availabilityRule } from './util';
+import type { RuleModule } from './types';
+
+const SH_FAMILY = new Set(['bash', 'sh', 'zsh', 'dash', 'ksh', 'ash']);
+
+export const PS030: RuleModule = availabilityRule(
+  {
+    id: 'PS030',
+    title: 'EXPLICIT_BASH',
+    summary: 'Scripts calling bash/sh/zsh depend on a Unix shell that stock Windows lacks.',
+    severity: 'warn',
+    confidence: 'high',
+    affectedTargets: ['cmd'],
+    badExamples: ['bash -c "rm -rf dist"', 'bash scripts/build.sh', 'sh ./deploy.sh'],
+    goodExamples: ['node scripts/build.js', 'rimraf dist'],
+    falsePositiveNotes:
+      'Wrapper payloads are never re-analyzed (no duplicate inner findings). Not reported when bash is an intentional, documented dependency — suppress via config in that case.',
+    fixSafety: 'manual',
+    provenance: [
+      {
+        source: 'https://learn.microsoft.com/en-us/windows/nodejs/beginners-tutorial-to-nodejs',
+        claim: 'A stock Windows Node.js install provides cmd.exe/PowerShell; bash requires WSL, Git Bash, or a manual install.',
+      },
+      {
+        source: 'https://docs.npmjs.com/cli/v10/using-npm/scripts',
+        claim: 'npm runs scripts with sh on Unix and cmd.exe on Windows by default.',
+      },
+    ],
+  },
+  {
+    names: SH_FAMILY,
+    message: (cmd) =>
+      `\`${cmd.argv[0]?.raw ?? ''}\` requires a POSIX shell; default Windows environments have none`,
+    fixSummary: 'document the shell dependency, rewrite in Node, or declare it in a platform-specific script',
+  },
+);

--- a/src/rules/PS030.ts
+++ b/src/rules/PS030.ts
@@ -2,8 +2,9 @@
  * PS030 — EXPLICIT_BASH: scripts invoking bash/sh/zsh depend on a shell that
  * default Windows environments do not have.
  */
-import { availabilityRule } from './util';
+
 import type { RuleModule } from './types';
+import { availabilityRule } from './util';
 
 const SH_FAMILY = new Set(['bash', 'sh', 'zsh', 'dash', 'ksh', 'ash']);
 
@@ -23,7 +24,8 @@ export const PS030: RuleModule = availabilityRule(
     provenance: [
       {
         source: 'https://learn.microsoft.com/en-us/windows/nodejs/beginners-tutorial-to-nodejs',
-        claim: 'A stock Windows Node.js install provides cmd.exe/PowerShell; bash requires WSL, Git Bash, or a manual install.',
+        claim:
+          'A stock Windows Node.js install provides cmd.exe/PowerShell; bash requires WSL, Git Bash, or a manual install.',
       },
       {
         source: 'https://docs.npmjs.com/cli/v10/using-npm/scripts',
@@ -35,6 +37,7 @@ export const PS030: RuleModule = availabilityRule(
     names: SH_FAMILY,
     message: (cmd) =>
       `\`${cmd.argv[0]?.raw ?? ''}\` requires a POSIX shell; default Windows environments have none`,
-    fixSummary: 'document the shell dependency, rewrite in Node, or declare it in a platform-specific script',
+    fixSummary:
+      'document the shell dependency, rewrite in Node, or declare it in a platform-specific script',
   },
 );

--- a/src/rules/PS031.ts
+++ b/src/rules/PS031.ts
@@ -1,0 +1,34 @@
+/**
+ * PS031 — EXPLICIT_CMD: `cmd /c …` makes the script unusable on macOS/Linux.
+ */
+import { availabilityRule } from './util';
+import type { RuleModule } from './types';
+
+const CMD_NAMES = new Set(['cmd', 'cmd.exe']);
+
+export const PS031: RuleModule = availabilityRule(
+  {
+    id: 'PS031',
+    title: 'EXPLICIT_CMD',
+    summary: '`cmd /c …` ties the script to Windows and fails on macOS/Linux.',
+    severity: 'warn',
+    confidence: 'high',
+    affectedTargets: ['posix-sh'],
+    badExamples: ['cmd /c "set FOO=bar&& node app.js"', 'cmd /c dir'],
+    goodExamples: ['node app.js', 'ls'],
+    falsePositiveNotes:
+      'Wrapper payloads are never re-analyzed. Intentional Windows-only scripts should be suppressed via config, not restructured by the linter.',
+    fixSafety: 'manual',
+    provenance: [
+      {
+        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/cmd',
+        claim: 'cmd.exe is the Windows command interpreter; it does not exist on macOS/Linux.',
+      },
+    ],
+  },
+  {
+    names: CMD_NAMES,
+    message: (cmd) => `\`${cmd.argv[0]?.raw ?? ''}\` is Windows-only and fails on macOS/Linux`,
+    fixSummary: 'replace with cross-platform logic or move the Windows-specific part to a platform-scoped script',
+  },
+);

--- a/src/rules/PS031.ts
+++ b/src/rules/PS031.ts
@@ -1,8 +1,9 @@
 /**
  * PS031 — EXPLICIT_CMD: `cmd /c …` makes the script unusable on macOS/Linux.
  */
-import { availabilityRule } from './util';
+
 import type { RuleModule } from './types';
+import { availabilityRule } from './util';
 
 const CMD_NAMES = new Set(['cmd', 'cmd.exe']);
 
@@ -21,7 +22,8 @@ export const PS031: RuleModule = availabilityRule(
     fixSafety: 'manual',
     provenance: [
       {
-        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/cmd',
+        source:
+          'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/cmd',
         claim: 'cmd.exe is the Windows command interpreter; it does not exist on macOS/Linux.',
       },
     ],
@@ -29,6 +31,7 @@ export const PS031: RuleModule = availabilityRule(
   {
     names: CMD_NAMES,
     message: (cmd) => `\`${cmd.argv[0]?.raw ?? ''}\` is Windows-only and fails on macOS/Linux`,
-    fixSummary: 'replace with cross-platform logic or move the Windows-specific part to a platform-scoped script',
+    fixSummary:
+      'replace with cross-platform logic or move the Windows-specific part to a platform-scoped script',
   },
 );

--- a/src/rules/PS032.ts
+++ b/src/rules/PS032.ts
@@ -1,0 +1,34 @@
+/**
+ * PS032 — EXPLICIT_POWERSHELL: powershell/pwsh wrappers are shell-specific.
+ */
+import { availabilityRule } from './util';
+import type { RuleModule } from './types';
+
+const PS_NAMES = new Set(['powershell', 'powershell.exe', 'pwsh', 'pwsh.exe']);
+
+export const PS032: RuleModule = availabilityRule(
+  {
+    id: 'PS032',
+    title: 'EXPLICIT_POWERSHELL',
+    summary: 'powershell/pwsh wrappers assume PowerShell exists (missing on stock macOS/Linux).',
+    severity: 'warn',
+    confidence: 'high',
+    affectedTargets: ['posix-sh'],
+    badExamples: ['powershell -Command "echo hi"', 'pwsh -File ./build.ps1'],
+    goodExamples: ['node ./build.js'],
+    falsePositiveNotes:
+      'Wrapper payloads are never re-analyzed. macOS can install pwsh, but a stock environment does not ship it.',
+    fixSafety: 'manual',
+    provenance: [
+      {
+        source: 'https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell',
+        claim: 'PowerShell is preinstalled on Windows only; macOS/Linux need a manual install.',
+      },
+    ],
+  },
+  {
+    names: PS_NAMES,
+    message: (cmd) => `\`${cmd.argv[0]?.raw ?? ''}\` requires PowerShell, which stock macOS/Linux lacks`,
+    fixSummary: 'declare the dependency explicitly or rewrite the step as cross-platform Node logic',
+  },
+);

--- a/src/rules/PS032.ts
+++ b/src/rules/PS032.ts
@@ -1,8 +1,9 @@
 /**
  * PS032 — EXPLICIT_POWERSHELL: powershell/pwsh wrappers are shell-specific.
  */
-import { availabilityRule } from './util';
+
 import type { RuleModule } from './types';
+import { availabilityRule } from './util';
 
 const PS_NAMES = new Set(['powershell', 'powershell.exe', 'pwsh', 'pwsh.exe']);
 
@@ -21,14 +22,17 @@ export const PS032: RuleModule = availabilityRule(
     fixSafety: 'manual',
     provenance: [
       {
-        source: 'https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell',
+        source:
+          'https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell',
         claim: 'PowerShell is preinstalled on Windows only; macOS/Linux need a manual install.',
       },
     ],
   },
   {
     names: PS_NAMES,
-    message: (cmd) => `\`${cmd.argv[0]?.raw ?? ''}\` requires PowerShell, which stock macOS/Linux lacks`,
-    fixSummary: 'declare the dependency explicitly or rewrite the step as cross-platform Node logic',
+    message: (cmd) =>
+      `\`${cmd.argv[0]?.raw ?? ''}\` requires PowerShell, which stock macOS/Linux lacks`,
+    fixSummary:
+      'declare the dependency explicitly or rewrite the step as cross-platform Node logic',
   },
 );

--- a/src/rules/PS032.ts
+++ b/src/rules/PS032.ts
@@ -16,7 +16,7 @@ export const PS032: RuleModule = availabilityRule(
     confidence: 'high',
     affectedTargets: ['posix-sh'],
     badExamples: ['powershell -Command "echo hi"', 'pwsh -File ./build.ps1'],
-    goodExamples: ['node ./build.js'],
+    goodExamples: ['node ./build.js', 'node scripts/build.mjs'],
     falsePositiveNotes:
       'Wrapper payloads are never re-analyzed. macOS can install pwsh, but a stock environment does not ship it.',
     fixSafety: 'manual',

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,0 +1,45 @@
+/**
+ * Rule registry and engine. Rules are standalone modules; the engine runs
+ * each rule, applies config severity overrides, filters by active targets
+ * and (optionally) by rule id, and returns deterministic sorted findings.
+ */
+import { parseScript } from '../parser/parse';
+import { sortFindings } from '../core/finding';
+import type { Finding, RuleContext, RuleModule, Severity } from './types';
+import type { ShellTarget } from '../parser/ir';
+import { PS001 } from './PS001';
+import { PS002 } from './PS002';
+import { PS003 } from './PS003';
+import { PS030 } from './PS030';
+import { PS031 } from './PS031';
+import { PS032 } from './PS032';
+
+export const RULES: readonly RuleModule[] = [PS001, PS002, PS003, PS030, PS031, PS032];
+
+export function getRule(id: string): RuleModule | undefined {
+  return RULES.find((r) => r.id === id);
+}
+
+export interface RunOptions {
+  /** Restrict to specific rule ids (CLI `--rule`). */
+  onlyRules?: ReadonlySet<string>;
+  /** Config severity overrides: rule id -> severity. */
+  severityOverrides?: ReadonlyMap<string, Severity>;
+}
+
+/** Analyze one script string and return findings for the active targets. */
+export function analyzeScript(script: string, ctx: RuleContext, options: RunOptions = {}): Finding[] {
+  const ir = parseScript(script);
+  const findings: Finding[] = [];
+  for (const rule of RULES) {
+    if (options.onlyRules !== undefined && !options.onlyRules.has(rule.id)) continue;
+    for (const finding of rule.check(ir, ctx)) {
+      const override = options.severityOverrides?.get(rule.id);
+      findings.push(override === undefined ? finding : { ...finding, severity: override });
+    }
+  }
+  return sortFindings(findings);
+}
+
+export type { Finding, RuleContext, RuleModule, Severity };
+export type { ShellTarget };

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -3,16 +3,17 @@
  * each rule, applies config severity overrides, filters by active targets
  * and (optionally) by rule id, and returns deterministic sorted findings.
  */
-import { parseScript } from '../parser/parse';
+
 import { sortFindings } from '../core/finding';
-import type { Finding, RuleContext, RuleModule, Severity } from './types';
 import type { ShellTarget } from '../parser/ir';
+import { parseScript } from '../parser/parse';
 import { PS001 } from './PS001';
 import { PS002 } from './PS002';
 import { PS003 } from './PS003';
 import { PS030 } from './PS030';
 import { PS031 } from './PS031';
 import { PS032 } from './PS032';
+import type { Finding, RuleContext, RuleModule, Severity } from './types';
 
 export const RULES: readonly RuleModule[] = [PS001, PS002, PS003, PS030, PS031, PS032];
 
@@ -28,7 +29,11 @@ export interface RunOptions {
 }
 
 /** Analyze one script string and return findings for the active targets. */
-export function analyzeScript(script: string, ctx: RuleContext, options: RunOptions = {}): Finding[] {
+export function analyzeScript(
+  script: string,
+  ctx: RuleContext,
+  options: RunOptions = {},
+): Finding[] {
   const ir = parseScript(script);
   const findings: Finding[] = [];
   for (const rule of RULES) {
@@ -41,5 +46,4 @@ export function analyzeScript(script: string, ctx: RuleContext, options: RunOpti
   return sortFindings(findings);
 }
 
-export type { Finding, RuleContext, RuleModule, Severity };
-export type { ShellTarget };
+export type { Finding, RuleContext, RuleModule, Severity, ShellTarget };

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -1,0 +1,75 @@
+/**
+ * Rule engine types: metadata contract, findings, and the per-script context
+ * rules analyze. All metadata fields are required (docs/contributing-rules.md).
+ */
+import type { ScriptIr, ScriptNode, ShellTarget } from '../parser/ir';
+
+export type Severity = 'error' | 'warn' | 'advisory';
+export type Confidence = 'high' | 'medium';
+export type FixSafety = 'safe' | 'conditional' | 'manual';
+
+export interface Provenance {
+  /** URL or citation backing the shell-behavior claim. */
+  source: string;
+  claim: string;
+}
+
+export interface FixCandidate {
+  ruleId: string;
+  safety: FixSafety;
+  description: string;
+  /** Text replacement in script-string coordinates (an insertion is a zero-length span). */
+  replacement?: { span: [number, number]; text: string };
+  /** Dependency that must already be installed before a conditional fix applies. */
+  requiresDependency?: string;
+}
+
+export interface Finding {
+  ruleId: string;
+  scriptName: string;
+  packagePath: string;
+  span: [number, number];
+  severity: Severity;
+  confidence: Confidence;
+  /** Shells this finding breaks, intersected with the active targets. */
+  affectedTargets: ShellTarget[];
+  message: string;
+  fix?: FixCandidate;
+}
+
+export interface RuleContext {
+  /** Raw script string; all spans index into this. */
+  script: string;
+  scriptName: string;
+  packagePath: string;
+  /** Active target shells for this run. */
+  targets: readonly ShellTarget[];
+  /** dependency + devDependency names of the analyzed package. */
+  dependencies: ReadonlySet<string>;
+  /** Bin names exposed by workspace packages (including this package's own bin). */
+  workspaceBins: ReadonlySet<string>;
+}
+
+export interface RuleMetadata {
+  id: string;
+  title: string;
+  summary: string;
+  severity: Severity;
+  confidence: Confidence;
+  /** Shells the pattern breaks (before intersecting with active targets). */
+  affectedTargets: readonly ShellTarget[];
+  badExamples: string[];
+  goodExamples: string[];
+  falsePositiveNotes: string;
+  fixSafety: FixSafety;
+  provenance: Provenance[];
+}
+
+export interface RuleModule extends RuleMetadata {
+  check(ir: ScriptIr, ctx: RuleContext): Finding[];
+}
+
+/** Utilities every rule receives for walking the IR. */
+export type Walker = {
+  walkCommands(node: ScriptNode): Generator<import('../parser/ir').CommandNode>;
+};

--- a/src/rules/util.ts
+++ b/src/rules/util.ts
@@ -3,10 +3,11 @@
  * factory used by PS010–PS019. Each rule stays a standalone module with its
  * own metadata; only the mechanical traversal is shared.
  */
-import { commandName, walkCommands } from '../parser/ir';
-import type { CommandNode, ScriptIr, ScriptNode } from '../parser/ir';
-import type { Finding, RuleContext, RuleModule } from './types';
+
 import { makeFinding } from '../core/finding';
+import type { CommandNode, ScriptIr, ScriptNode } from '../parser/ir';
+import { commandName, walkCommands } from '../parser/ir';
+import type { Finding, RuleContext, RuleModule } from './types';
 
 /** Tools whose usage already implies the portability problem is handled. */
 export const PORTABILITY_TOOLS = new Set(['cross-env', 'cross-env-shell', 'shx', 'rimraf']);
@@ -92,5 +93,8 @@ export function isCommand(cmd: CommandNode, name: string): boolean {
 
 /** Lowercased flag arguments (tokens starting with `-`) of a command. */
 export function flagsOf(cmd: CommandNode): string[] {
-  return cmd.argv.slice(1).map((t) => t.value).filter((v) => v.startsWith('-'));
+  return cmd.argv
+    .slice(1)
+    .map((t) => t.value)
+    .filter((v) => v.startsWith('-'));
 }

--- a/src/rules/util.ts
+++ b/src/rules/util.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared rule helpers: IR walking and the POSIX command-availability rule
+ * factory used by PS010–PS019. Each rule stays a standalone module with its
+ * own metadata; only the mechanical traversal is shared.
+ */
+import { commandName, walkCommands } from '../parser/ir';
+import type { CommandNode, ScriptIr, ScriptNode } from '../parser/ir';
+import type { Finding, RuleContext, RuleModule } from './types';
+import { makeFinding } from '../core/finding';
+
+/** Tools whose usage already implies the portability problem is handled. */
+export const PORTABILITY_TOOLS = new Set(['cross-env', 'cross-env-shell', 'shx', 'rimraf']);
+
+/** Collect sequence operators (`;`, `&`, newline) used anywhere in the tree. */
+export function collectSequenceOps(
+  node: ScriptNode,
+  acc: { op: string; span: [number, number] }[] = [],
+): { op: string; span: [number, number] }[] {
+  switch (node.kind) {
+    case 'sequence':
+      node.ops.forEach((op, i) => {
+        const span = node.opSpans[i];
+        if (span !== undefined) acc.push({ op, span });
+      });
+      for (const part of node.parts) collectSequenceOps(part, acc);
+      return acc;
+    case 'boolean':
+    case 'pipeline':
+      for (const part of node.parts) collectSequenceOps(part, acc);
+      return acc;
+    case 'group':
+      return collectSequenceOps(node.body, acc);
+    default:
+      return acc;
+  }
+}
+
+/** Yield every command in the tree (never descends into wrapper payloads). */
+export function commandsOf(ir: ScriptIr): CommandNode[] {
+  return [...walkCommands(ir.root)];
+}
+
+export interface AvailabilityOptions {
+  /** Command names the rule matches (lowercase). */
+  names: ReadonlySet<string>;
+  message: (cmd: CommandNode) => string;
+  fixSummary: string;
+  /** Extra guard; return false to skip this command. */
+  matches?: (cmd: CommandNode) => boolean;
+}
+
+/**
+ * Factory for “command X does not exist / differs on target shells” rules.
+ * Findings anchor on argv[0]; tools that already solve portability
+ * (shx/rimraf/…) never appear in command position, so they never fire.
+ */
+export function availabilityRule(
+  rule: Omit<RuleModule, 'check'>,
+  options: AvailabilityOptions,
+): RuleModule {
+  return {
+    ...rule,
+    check(ir: ScriptIr, ctx: RuleContext): Finding[] {
+      const findings: Finding[] = [];
+      for (const cmd of commandsOf(ir)) {
+        const name = commandName(cmd);
+        if (name === null) continue;
+        if (!options.names.has(name.toLowerCase())) continue;
+        if (options.matches && !options.matches(cmd)) continue;
+        const first = cmd.argv[0];
+        if (first === undefined) continue;
+        const finding = makeFinding(rule, ctx, {
+          message: options.message(cmd),
+          span: first.span,
+          fix: {
+            ruleId: rule.id,
+            safety: rule.fixSafety,
+            description: options.fixSummary,
+          },
+        });
+        if (finding !== null) findings.push(finding);
+      }
+      return findings;
+    },
+  };
+}
+
+/** True when the command name (lowercased) equals `name`. */
+export function isCommand(cmd: CommandNode, name: string): boolean {
+  return commandName(cmd)?.toLowerCase() === name;
+}
+
+/** Lowercased flag arguments (tokens starting with `-`) of a command. */
+export function flagsOf(cmd: CommandNode): string[] {
+  return cmd.argv.slice(1).map((t) => t.value).filter((v) => v.startsWith('-'));
+}

--- a/tests/rules/engine.test.ts
+++ b/tests/rules/engine.test.ts
@@ -19,9 +19,13 @@ describe('rule engine', () => {
   });
 
   it('severity overrides from config are applied', () => {
-    const findings = analyzeScript('NODE_ENV=x vite build', makeCtx({ script: 'NODE_ENV=x vite build' }), {
-      severityOverrides: new Map([['PS001', 'advisory']]),
-    });
+    const findings = analyzeScript(
+      'NODE_ENV=x vite build',
+      makeCtx({ script: 'NODE_ENV=x vite build' }),
+      {
+        severityOverrides: new Map([['PS001', 'advisory']]),
+      },
+    );
     expect(findings[0]?.severity).toBe('advisory');
   });
 
@@ -46,7 +50,11 @@ describe('rule engine', () => {
   it('findings carry script and package identity', () => {
     const findings = analyzeScript(
       'NODE_ENV=x vite build',
-      makeCtx({ script: 'NODE_ENV=x vite build', scriptName: 'build', packagePath: 'packages/web/package.json' }),
+      makeCtx({
+        script: 'NODE_ENV=x vite build',
+        scriptName: 'build',
+        packagePath: 'packages/web/package.json',
+      }),
     );
     expect(findings[0]?.scriptName).toBe('build');
     expect(findings[0]?.packagePath).toBe('packages/web/package.json');

--- a/tests/rules/engine.test.ts
+++ b/tests/rules/engine.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { analyzeScript, RULES } from '../../src/rules/index';
+import { makeCtx } from './helpers';
+
+describe('rule engine', () => {
+  it('every rule ships complete metadata', () => {
+    for (const rule of RULES) {
+      expect(rule.id, rule.id).toMatch(/^PS\d{3}$/);
+      expect(rule.title, rule.id).toBeTruthy();
+      expect(rule.summary, rule.id).toBeTruthy();
+      expect(rule.badExamples.length, rule.id).toBeGreaterThanOrEqual(2);
+      expect(rule.goodExamples.length, rule.id).toBeGreaterThanOrEqual(2);
+      expect(rule.falsePositiveNotes, rule.id).toBeTruthy();
+      expect(rule.provenance.length, rule.id).toBeGreaterThanOrEqual(1);
+      expect(['error', 'warn', 'advisory'], rule.id).toContain(rule.severity);
+      expect(['high', 'medium'], rule.id).toContain(rule.confidence);
+      expect(['safe', 'conditional', 'manual'], rule.id).toContain(rule.fixSafety);
+    }
+  });
+
+  it('severity overrides from config are applied', () => {
+    const findings = analyzeScript('NODE_ENV=x vite build', makeCtx({ script: 'NODE_ENV=x vite build' }), {
+      severityOverrides: new Map([['PS001', 'advisory']]),
+    });
+    expect(findings[0]?.severity).toBe('advisory');
+  });
+
+  it('onlyRules restricts execution', () => {
+    const findings = analyzeScript(
+      'NODE_ENV=x vite build && rm -rf dist && bash -c "echo hi"',
+      makeCtx({ script: 'x' }),
+      { onlyRules: new Set(['PS001']) },
+    );
+    expect(findings.map((f) => f.ruleId)).toEqual(['PS001']);
+  });
+
+  it('findings are sorted by span', () => {
+    const findings = analyzeScript(
+      'rm -rf dist && NODE_ENV=x vite build',
+      makeCtx({ script: 'rm -rf dist && NODE_ENV=x vite build' }),
+    );
+    const spans = findings.map((f) => f.span[0]);
+    expect([...spans].sort((a, b) => a - b)).toEqual(spans);
+  });
+
+  it('findings carry script and package identity', () => {
+    const findings = analyzeScript(
+      'NODE_ENV=x vite build',
+      makeCtx({ script: 'NODE_ENV=x vite build', scriptName: 'build', packagePath: 'packages/web/package.json' }),
+    );
+    expect(findings[0]?.scriptName).toBe('build');
+    expect(findings[0]?.packagePath).toBe('packages/web/package.json');
+  });
+});

--- a/tests/rules/helpers.ts
+++ b/tests/rules/helpers.ts
@@ -1,7 +1,8 @@
 /** Shared helpers for rule tests: minimal context + result shaping. */
+
+import { DEFAULT_TARGETS } from '../../src/core/targets';
 import { analyzeScript } from '../../src/rules/index';
 import type { Finding, RuleContext } from '../../src/rules/types';
-import { DEFAULT_TARGETS } from '../../src/core/targets';
 
 export function makeCtx(partial: Partial<RuleContext> = {}): RuleContext {
   return {

--- a/tests/rules/helpers.ts
+++ b/tests/rules/helpers.ts
@@ -1,0 +1,28 @@
+/** Shared helpers for rule tests: minimal context + result shaping. */
+import { analyzeScript } from '../../src/rules/index';
+import type { Finding, RuleContext } from '../../src/rules/types';
+import { DEFAULT_TARGETS } from '../../src/core/targets';
+
+export function makeCtx(partial: Partial<RuleContext> = {}): RuleContext {
+  return {
+    script: '',
+    scriptName: 'test',
+    packagePath: 'package.json',
+    targets: DEFAULT_TARGETS,
+    dependencies: new Set<string>(),
+    workspaceBins: new Set<string>(),
+    ...partial,
+  };
+}
+
+export function run(script: string, partial: Partial<RuleContext> = {}): Finding[] {
+  return analyzeScript(script, makeCtx({ ...partial, script }));
+}
+
+export function ids(findings: Finding[]): string[] {
+  return findings.map((f) => f.ruleId);
+}
+
+export function only(findings: Finding[], ruleId: string): Finding[] {
+  return findings.filter((f) => f.ruleId === ruleId);
+}

--- a/tests/rules/ps001.test.ts
+++ b/tests/rules/ps001.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { ids, only, run } from './helpers';
+
+describe('PS001 POSIX_INLINE_ENV', () => {
+  it('positive: reports inline env assignments', () => {
+    expect(ids(only(run('NODE_ENV=production vite build'), 'PS001'))).toEqual(['PS001']);
+    expect(only(run('A=1 B=2 node app.js'), 'PS001')).toHaveLength(1);
+    expect(only(run('GIT_AUTHOR_NAME=x npm publish'), 'PS001')).toHaveLength(1);
+  });
+
+  it('positive: assignment-only scripts are still POSIX-only', () => {
+    expect(only(run('FOO=bar'), 'PS001')).toHaveLength(1);
+  });
+
+  it('positive: reports assignments in chained commands', () => {
+    expect(only(run('node a.js && B=2 node b.js'), 'PS001')).toHaveLength(1);
+  });
+
+  it('negative: cross-env already handles it', () => {
+    expect(only(run('cross-env NODE_ENV=production vite build'), 'PS001')).toEqual([]);
+  });
+
+  it('negative: plain commands without assignments', () => {
+    expect(only(run('vite build'), 'PS001')).toEqual([]);
+    expect(only(run('node app.js'), 'PS001')).toEqual([]);
+  });
+
+  it('negative: strings containing equals are not assignments', () => {
+    expect(only(run('echo "FOO=bar"'), 'PS001')).toEqual([]);
+    expect(only(run('vite --mode=production'), 'PS001')).toEqual([]);
+  });
+
+  it('negative: not reported when cmd is not an active target', () => {
+    expect(only(run('NODE_ENV=x vite build', { targets: ['posix-sh'] }), 'PS001')).toEqual([]);
+  });
+
+  it('fix: safe when cross-env is already a dependency', () => {
+    const [f] = only(run('NODE_ENV=production vite build', { dependencies: new Set(['cross-env']) }), 'PS001');
+    expect(f?.fix?.safety).toBe('safe');
+    expect(f?.fix?.replacement?.text).toBe('cross-env ');
+  });
+
+  it('fix: conditional (plan only) when cross-env is missing', () => {
+    const [f] = only(run('NODE_ENV=production vite build'), 'PS001');
+    expect(f?.fix?.safety).toBe('conditional');
+    expect(f?.fix?.requiresDependency).toBe('cross-env');
+    expect(f?.fix?.replacement).toBeUndefined();
+  });
+});

--- a/tests/rules/ps001.test.ts
+++ b/tests/rules/ps001.test.ts
@@ -35,7 +35,10 @@ describe('PS001 POSIX_INLINE_ENV', () => {
   });
 
   it('fix: safe when cross-env is already a dependency', () => {
-    const [f] = only(run('NODE_ENV=production vite build', { dependencies: new Set(['cross-env']) }), 'PS001');
+    const [f] = only(
+      run('NODE_ENV=production vite build', { dependencies: new Set(['cross-env']) }),
+      'PS001',
+    );
     expect(f?.fix?.safety).toBe('safe');
     expect(f?.fix?.replacement?.text).toBe('cross-env ');
   });

--- a/tests/rules/ps002.test.ts
+++ b/tests/rules/ps002.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { only, run } from './helpers';
+
+describe('PS002 CMD_SET_ENV', () => {
+  it('positive: set NAME=value&& chain', () => {
+    const findings = only(run('set NODE_ENV=production&& node app.js'), 'PS002');
+    expect(findings).toHaveLength(1);
+  });
+
+  it('positive: set with trailing space variants', () => {
+    expect(only(run('set FOO=bar&& vite build'), 'PS002')).toHaveLength(1);
+    expect(only(run('set FOO=bar && vite build'), 'PS002')).toHaveLength(1);
+  });
+
+  it('positive: inside a longer chain', () => {
+    expect(only(run('node a.js && set X=1&& node b.js'), 'PS002')).toHaveLength(1);
+  });
+
+  it('negative: POSIX set options are not env assignments', () => {
+    expect(only(run('set -e'), 'PS002')).toEqual([]);
+    expect(only(run('set -o pipefail && npm test'), 'PS002')).toEqual([]);
+  });
+
+  it('negative: plain set without NAME=value argument', () => {
+    expect(only(run('set'), 'PS002')).toEqual([]);
+  });
+
+  it('negative: other commands', () => {
+    expect(only(run('node app.js'), 'PS002')).toEqual([]);
+  });
+
+  it('severity is warn and affected target is posix-sh', () => {
+    const [f] = only(run('set X=1&& node b'), 'PS002');
+    expect(f?.severity).toBe('warn');
+    expect(f?.affectedTargets).toEqual(['posix-sh']);
+  });
+});

--- a/tests/rules/ps003.test.ts
+++ b/tests/rules/ps003.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { only, run } from './helpers';
+
+describe('PS003 POWERSHELL_ENV', () => {
+  it('positive: bare $env: assignment in npm scripts', () => {
+    expect(only(run("$env:NODE_ENV='production'; node app.js"), 'PS003')).toHaveLength(1);
+  });
+
+  it('positive: $env:PATH mutation', () => {
+    expect(only(run("$env:PATH='whatever'; npm test"), 'PS003')).toHaveLength(1);
+  });
+
+  it('positive: $env: inside a chained command', () => {
+    expect(only(run("node a.js && $env:X='1'; node b.js"), 'PS003')).toHaveLength(1);
+  });
+
+  it('negative: inside an explicit powershell wrapper (PS032 owns it)', () => {
+    const findings = only(run('powershell -Command "$env:FOO=\'bar\'; node app.js"'), 'PS003');
+    expect(findings).toEqual([]);
+  });
+
+  it('negative: ordinary node env usage', () => {
+    expect(only(run('node -e "console.log(process.env.HOME)"'), 'PS003')).toEqual([]);
+  });
+
+  it('negative: plain $VAR is PS023 territory, not PS003', () => {
+    expect(only(run('echo $HOME'), 'PS003')).toEqual([]);
+  });
+});

--- a/tests/rules/ps030.test.ts
+++ b/tests/rules/ps030.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { ids, only, run } from './helpers';
+
+describe('PS030 EXPLICIT_BASH', () => {
+  it('positive: bash -c wrapper', () => {
+    const findings = only(run('bash -c "rm -rf dist"'), 'PS030');
+    expect(findings).toHaveLength(1);
+  });
+
+  it('positive: sh and zsh wrappers', () => {
+    expect(only(run('sh -c "echo hi"'), 'PS030')).toHaveLength(1);
+    expect(only(run('zsh -c "echo hi"'), 'PS030')).toHaveLength(1);
+  });
+
+  it('positive: bash running a script file', () => {
+    expect(only(run('bash scripts/build.sh'), 'PS030')).toHaveLength(1);
+  });
+
+  it('does not double-report inner tokens (wrapper owns the finding)', () => {
+    const findings = run('bash -c "rm -rf dist"');
+    expect(ids(findings)).toEqual(['PS030']);
+  });
+
+  it('negative: node scripts are cross-platform', () => {
+    expect(only(run('node scripts/build.js'), 'PS030')).toEqual([]);
+  });
+
+  it('negative: cross-platform tools', () => {
+    expect(only(run('rimraf dist'), 'PS030')).toEqual([]);
+    expect(only(run('shx rm -rf dist'), 'PS030')).toEqual([]);
+  });
+
+  it('fix is manual (dependency declaration decision)', () => {
+    const [f] = only(run('bash -c "echo hi"'), 'PS030');
+    expect(f?.fix?.safety).toBe('manual');
+  });
+});

--- a/tests/rules/ps031-032.test.ts
+++ b/tests/rules/ps031-032.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { ids, only, run } from './helpers';
+
+describe('PS031 EXPLICIT_CMD', () => {
+  it('positive: cmd /c wrapper', () => {
+    const findings = only(run('cmd /c "set FOO=bar&& node app.js"'), 'PS031');
+    expect(findings).toHaveLength(1);
+  });
+
+  it('positive: cmd.exe form', () => {
+    expect(only(run('cmd.exe /c dir'), 'PS031')).toHaveLength(1);
+  });
+
+  it('wrapper owns the finding; inner tokens are not re-reported', () => {
+    expect(ids(run('cmd /c "set FOO=bar&& node app.js"'))).toEqual(['PS031']);
+  });
+
+  it('negative: cross-platform commands', () => {
+    expect(only(run('node app.js'), 'PS031')).toEqual([]);
+    expect(only(run('vite build'), 'PS031')).toEqual([]);
+  });
+
+  it('negative: not reported when only targeting cmd', () => {
+    expect(only(run('cmd /c "dir"', { targets: ['cmd'] }), 'PS031')).toEqual([]);
+  });
+});
+
+describe('PS032 EXPLICIT_POWERSHELL', () => {
+  it('positive: powershell -Command wrapper', () => {
+    expect(only(run('powershell -Command "echo hi"'), 'PS032')).toHaveLength(1);
+  });
+
+  it('positive: pwsh and -NoProfile forms', () => {
+    expect(only(run('pwsh -Command "echo hi"'), 'PS032')).toHaveLength(1);
+    expect(only(run('powershell -NoProfile -Command "echo hi"'), 'PS032')).toHaveLength(1);
+  });
+
+  it('wrapper owns the finding; inner $env: is not re-reported', () => {
+    expect(ids(run(`powershell -Command "$env:FOO='bar'; node app.js"`))).toEqual(['PS032']);
+  });
+
+  it('negative: node scripts', () => {
+    expect(only(run('node app.js'), 'PS032')).toEqual([]);
+  });
+
+  it('negative: not reported when powershell is an explicit target', () => {
+    expect(only(run('pwsh -Command "x"', { targets: ['cmd', 'powershell'] }), 'PS032')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Adds the rule engine (registry, target filtering, config severity overrides, deterministic ordering) and the first six v0.1 rules: PS001 (POSIX inline env, error/high, conditional cross-env fix), PS002 (cmd set env), PS003 (PowerShell env), PS030/031/032 (explicit bash/cmd/powershell dependencies). Wrapper payloads are reported once via the wrapper finding and never rescanned.

## Why
Milestone M2 part 1 (spec §6): environment-assignment and explicit-shell rules are the highest-value, highest-confidence portability failures.

## Rule semantics changed?
New rules only — no existing behavior changes.

## Test evidence
Engine metadata test enforces every §6.1 field (≥2 bad/good examples, provenance, fixSafety); each rule ships ≥3 positive + ≥3 negative fixtures; CI must be green on all three OSes.

## Risk and rollback
New modules behind the registry; nothing else consumes them yet. Revert the single commit if needed.

## Checklist
- [x] Tests added (6 rules × 6+ cases + engine tests)
- [x] No new runtime dependency
- [x] No execution of analyzed scripts; no telemetry
- [x] Third-party actions pinned