### PR TITLE
feat(rules): POSIX command + syntax rules PS010-PS026 (M2 part 2)

### DIFF
--- a/src/rules/PS010.ts
+++ b/src/rules/PS010.ts
@@ -1,0 +1,38 @@
+/**
+ * PS010 — POSIX_RM: `rm` (and `rm -rf`) does not exist in native Windows
+ * npm scripts (cmd.exe).
+ */
+import { availabilityRule } from './util';
+import type { RuleModule } from './types';
+
+export const PS010: RuleModule = availabilityRule(
+  {
+    id: 'PS010',
+    title: 'POSIX_RM',
+    summary: '`rm` / `rm -rf` is not available in native Windows npm scripts.',
+    severity: 'error',
+    confidence: 'high',
+    affectedTargets: ['cmd'],
+    badExamples: ['rm -rf dist', 'rm -r build', 'rm temp.log'],
+    goodExamples: ['rimraf dist', 'shx rm -rf dist', 'node -e "require(\'fs\').rmSync(\'dist\',{recursive:true,force:true})"'],
+    falsePositiveNotes:
+      'Not reported for `rimraf …` or `shx rm …` (command position is the tool), nor for rm inside strings or shell-wrapper payloads.',
+    fixSafety: 'conditional',
+    provenance: [
+      {
+        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/windows-commands',
+        claim: 'cmd.exe has del/rmdir, not rm; `rm -rf dist` fails with "rm is not recognized".',
+      },
+      {
+        source: 'https://github.com/isaacs/rimraf#readme',
+        claim: 'rimraf provides a cross-platform rm -rf equivalent for Node projects.',
+      },
+    ],
+  },
+  {
+    names: new Set(['rm']),
+    message: (cmd) =>
+      `\`${cmd.raw.split(' ').slice(0, 2).join(' ')}\` is not available in native Windows npm scripts`,
+    fixSummary: 'use rimraf (devDependency), shx rm, or Node fs.rm',
+  },
+);

--- a/src/rules/PS010.ts
+++ b/src/rules/PS010.ts
@@ -2,8 +2,9 @@
  * PS010 — POSIX_RM: `rm` (and `rm -rf`) does not exist in native Windows
  * npm scripts (cmd.exe).
  */
-import { availabilityRule } from './util';
+
 import type { RuleModule } from './types';
+import { availabilityRule } from './util';
 
 export const PS010: RuleModule = availabilityRule(
   {
@@ -14,13 +15,18 @@ export const PS010: RuleModule = availabilityRule(
     confidence: 'high',
     affectedTargets: ['cmd'],
     badExamples: ['rm -rf dist', 'rm -r build', 'rm temp.log'],
-    goodExamples: ['rimraf dist', 'shx rm -rf dist', 'node -e "require(\'fs\').rmSync(\'dist\',{recursive:true,force:true})"'],
+    goodExamples: [
+      'rimraf dist',
+      'shx rm -rf dist',
+      "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
+    ],
     falsePositiveNotes:
       'Not reported for `rimraf …` or `shx rm …` (command position is the tool), nor for rm inside strings or shell-wrapper payloads.',
     fixSafety: 'conditional',
     provenance: [
       {
-        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/windows-commands',
+        source:
+          'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/windows-commands',
         claim: 'cmd.exe has del/rmdir, not rm; `rm -rf dist` fails with "rm is not recognized".',
       },
       {

--- a/src/rules/PS011.ts
+++ b/src/rules/PS011.ts
@@ -1,0 +1,31 @@
+/**
+ * PS011 — POSIX_CP: `cp` / `cp -r` does not exist under cmd.exe.
+ */
+import { availabilityRule } from './util';
+import type { RuleModule } from './types';
+
+export const PS011: RuleModule = availabilityRule(
+  {
+    id: 'PS011',
+    title: 'POSIX_CP',
+    summary: '`cp` / `cp -r` is not available in native Windows npm scripts.',
+    severity: 'error',
+    confidence: 'high',
+    affectedTargets: ['cmd'],
+    badExamples: ['cp -r src dist', 'cp a.txt b.txt'],
+    goodExamples: ['shx cp -r src dist', 'node -e "require(\'fs\').cpSync(\'src\',\'dist\',{recursive:true})"'],
+    falsePositiveNotes: 'Not reported for `shx cp …` or cp inside strings/wrapper payloads.',
+    fixSafety: 'conditional',
+    provenance: [
+      {
+        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/copy',
+        claim: 'cmd.exe uses copy/xcopy/robocopy; `cp` is not recognized.',
+      },
+    ],
+  },
+  {
+    names: new Set(['cp']),
+    message: (cmd) => `\`${cmd.argv[0]?.raw ?? 'cp'}\` is not available in native Windows npm scripts`,
+    fixSummary: 'use shx cp or Node fs.cp',
+  },
+);

--- a/src/rules/PS011.ts
+++ b/src/rules/PS011.ts
@@ -1,8 +1,9 @@
 /**
  * PS011 — POSIX_CP: `cp` / `cp -r` does not exist under cmd.exe.
  */
-import { availabilityRule } from './util';
+
 import type { RuleModule } from './types';
+import { availabilityRule } from './util';
 
 export const PS011: RuleModule = availabilityRule(
   {
@@ -13,19 +14,24 @@ export const PS011: RuleModule = availabilityRule(
     confidence: 'high',
     affectedTargets: ['cmd'],
     badExamples: ['cp -r src dist', 'cp a.txt b.txt'],
-    goodExamples: ['shx cp -r src dist', 'node -e "require(\'fs\').cpSync(\'src\',\'dist\',{recursive:true})"'],
+    goodExamples: [
+      'shx cp -r src dist',
+      "node -e \"require('fs').cpSync('src','dist',{recursive:true})\"",
+    ],
     falsePositiveNotes: 'Not reported for `shx cp …` or cp inside strings/wrapper payloads.',
     fixSafety: 'conditional',
     provenance: [
       {
-        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/copy',
+        source:
+          'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/copy',
         claim: 'cmd.exe uses copy/xcopy/robocopy; `cp` is not recognized.',
       },
     ],
   },
   {
     names: new Set(['cp']),
-    message: (cmd) => `\`${cmd.argv[0]?.raw ?? 'cp'}\` is not available in native Windows npm scripts`,
+    message: (cmd) =>
+      `\`${cmd.argv[0]?.raw ?? 'cp'}\` is not available in native Windows npm scripts`,
     fixSummary: 'use shx cp or Node fs.cp',
   },
 );

--- a/src/rules/PS012.ts
+++ b/src/rules/PS012.ts
@@ -1,8 +1,9 @@
 /**
  * PS012 — POSIX_MV: `mv` does not exist under cmd.exe.
  */
-import { availabilityRule } from './util';
+
 import type { RuleModule } from './types';
+import { availabilityRule } from './util';
 
 export const PS012: RuleModule = availabilityRule(
   {
@@ -13,12 +14,13 @@ export const PS012: RuleModule = availabilityRule(
     confidence: 'high',
     affectedTargets: ['cmd'],
     badExamples: ['mv dist build', 'mv old.json new.json'],
-    goodExamples: ['shx mv dist build', 'node -e "require(\'fs\').renameSync(\'a\',\'b\')"'],
+    goodExamples: ['shx mv dist build', "node -e \"require('fs').renameSync('a','b')\""],
     falsePositiveNotes: 'Not reported for `shx mv …` or mv inside strings/wrapper payloads.',
     fixSafety: 'conditional',
     provenance: [
       {
-        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/move',
+        source:
+          'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/move',
         claim: 'cmd.exe uses move; `mv` is not recognized.',
       },
     ],

--- a/src/rules/PS012.ts
+++ b/src/rules/PS012.ts
@@ -1,0 +1,31 @@
+/**
+ * PS012 — POSIX_MV: `mv` does not exist under cmd.exe.
+ */
+import { availabilityRule } from './util';
+import type { RuleModule } from './types';
+
+export const PS012: RuleModule = availabilityRule(
+  {
+    id: 'PS012',
+    title: 'POSIX_MV',
+    summary: '`mv` is not available in native Windows npm scripts.',
+    severity: 'error',
+    confidence: 'high',
+    affectedTargets: ['cmd'],
+    badExamples: ['mv dist build', 'mv old.json new.json'],
+    goodExamples: ['shx mv dist build', 'node -e "require(\'fs\').renameSync(\'a\',\'b\')"'],
+    falsePositiveNotes: 'Not reported for `shx mv …` or mv inside strings/wrapper payloads.',
+    fixSafety: 'conditional',
+    provenance: [
+      {
+        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/move',
+        claim: 'cmd.exe uses move; `mv` is not recognized.',
+      },
+    ],
+  },
+  {
+    names: new Set(['mv']),
+    message: () => '`mv` is not available in native Windows npm scripts',
+    fixSummary: 'use shx mv or Node fs.rename',
+  },
+);

--- a/src/rules/PS013.ts
+++ b/src/rules/PS013.ts
@@ -2,12 +2,15 @@
  * PS013 — POSIX_MKDIR_P: `mkdir -p` (create parents, ok if exists) has no
  * equivalent flag form under cmd.exe.
  */
-import { availabilityRule, flagsOf } from './util';
+
 import type { CommandNode } from '../parser/ir';
 import type { RuleModule } from './types';
+import { availabilityRule, flagsOf } from './util';
 
 function hasParentsFlag(cmd: CommandNode): boolean {
-  return flagsOf(cmd).some((f) => f === '-p' || f === '--parents' || (/^-[a-zA-Z]{1,4}$/.test(f) && f.includes('p')));
+  return flagsOf(cmd).some(
+    (f) => f === '-p' || f === '--parents' || (/^-[a-zA-Z]{1,4}$/.test(f) && f.includes('p')),
+  );
 }
 
 export const PS013: RuleModule = availabilityRule(
@@ -19,7 +22,10 @@ export const PS013: RuleModule = availabilityRule(
     confidence: 'high',
     affectedTargets: ['cmd'],
     badExamples: ['mkdir -p dist/assets', 'mkdir -p a/b/c'],
-    goodExamples: ['shx mkdir -p dist/assets', 'node -e "require(\'fs\').mkdirSync(\'a/b/c\',{recursive:true})"'],
+    goodExamples: [
+      'shx mkdir -p dist/assets',
+      "node -e \"require('fs').mkdirSync('a/b/c',{recursive:true})\"",
+    ],
     falsePositiveNotes:
       'Plain `mkdir` (no -p/--parents) is not reported: cmd.exe has mkdir and `mkdir a\\b` creates parents. Only the flag form differs.',
     fixSafety: 'conditional',
@@ -29,7 +35,8 @@ export const PS013: RuleModule = availabilityRule(
         claim: 'POSIX -p creates missing parents and does not error when the directory exists.',
       },
       {
-        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/mkdir',
+        source:
+          'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/mkdir',
         claim: 'cmd.exe mkdir errors when the directory already exists and has no -p flag.',
       },
     ],
@@ -37,7 +44,8 @@ export const PS013: RuleModule = availabilityRule(
   {
     names: new Set(['mkdir']),
     matches: hasParentsFlag,
-    message: (cmd) => `\`${cmd.argv[0]?.raw ?? 'mkdir'} ${flagsOf(cmd).join(' ')}\` is not portable to cmd.exe`,
+    message: (cmd) =>
+      `\`${cmd.argv[0]?.raw ?? 'mkdir'} ${flagsOf(cmd).join(' ')}\` is not portable to cmd.exe`,
     fixSummary: 'use shx mkdir -p or Node fs.mkdir recursive',
   },
 );

--- a/src/rules/PS013.ts
+++ b/src/rules/PS013.ts
@@ -1,0 +1,43 @@
+/**
+ * PS013 — POSIX_MKDIR_P: `mkdir -p` (create parents, ok if exists) has no
+ * equivalent flag form under cmd.exe.
+ */
+import { availabilityRule, flagsOf } from './util';
+import type { CommandNode } from '../parser/ir';
+import type { RuleModule } from './types';
+
+function hasParentsFlag(cmd: CommandNode): boolean {
+  return flagsOf(cmd).some((f) => f === '-p' || f === '--parents' || (/^-[a-zA-Z]{1,4}$/.test(f) && f.includes('p')));
+}
+
+export const PS013: RuleModule = availabilityRule(
+  {
+    id: 'PS013',
+    title: 'POSIX_MKDIR_P',
+    summary: '`mkdir -p` semantics (create parents, ignore existing) do not carry over to cmd.exe.',
+    severity: 'error',
+    confidence: 'high',
+    affectedTargets: ['cmd'],
+    badExamples: ['mkdir -p dist/assets', 'mkdir -p a/b/c'],
+    goodExamples: ['shx mkdir -p dist/assets', 'node -e "require(\'fs\').mkdirSync(\'a/b/c\',{recursive:true})"'],
+    falsePositiveNotes:
+      'Plain `mkdir` (no -p/--parents) is not reported: cmd.exe has mkdir and `mkdir a\\b` creates parents. Only the flag form differs.',
+    fixSafety: 'conditional',
+    provenance: [
+      {
+        source: 'https://pubs.opengroup.org/onlinepubs/9699919799/utilities/mkdir.html',
+        claim: 'POSIX -p creates missing parents and does not error when the directory exists.',
+      },
+      {
+        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/mkdir',
+        claim: 'cmd.exe mkdir errors when the directory already exists and has no -p flag.',
+      },
+    ],
+  },
+  {
+    names: new Set(['mkdir']),
+    matches: hasParentsFlag,
+    message: (cmd) => `\`${cmd.argv[0]?.raw ?? 'mkdir'} ${flagsOf(cmd).join(' ')}\` is not portable to cmd.exe`,
+    fixSummary: 'use shx mkdir -p or Node fs.mkdir recursive',
+  },
+);

--- a/src/rules/PS014.ts
+++ b/src/rules/PS014.ts
@@ -1,8 +1,9 @@
 /**
  * PS014 — POSIX_TOUCH: `touch` does not exist under cmd.exe.
  */
-import { availabilityRule } from './util';
+
 import type { RuleModule } from './types';
+import { availabilityRule } from './util';
 
 export const PS014: RuleModule = availabilityRule(
   {
@@ -18,7 +19,8 @@ export const PS014: RuleModule = availabilityRule(
     fixSafety: 'manual',
     provenance: [
       {
-        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/windows-commands',
+        source:
+          'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/windows-commands',
         claim: 'cmd.exe has no touch; typical workarounds are `type nul > file` or copy nul.',
       },
     ],

--- a/src/rules/PS014.ts
+++ b/src/rules/PS014.ts
@@ -1,0 +1,31 @@
+/**
+ * PS014 — POSIX_TOUCH: `touch` does not exist under cmd.exe.
+ */
+import { availabilityRule } from './util';
+import type { RuleModule } from './types';
+
+export const PS014: RuleModule = availabilityRule(
+  {
+    id: 'PS014',
+    title: 'POSIX_TOUCH',
+    summary: '`touch` is not available in native Windows npm scripts.',
+    severity: 'error',
+    confidence: 'high',
+    affectedTargets: ['cmd'],
+    badExamples: ['touch build.timestamp', 'touch src/generated.ts'],
+    goodExamples: ['node scripts/make-marker.js', 'echo ok > build.timestamp'],
+    falsePositiveNotes: 'Not reported inside strings or shell-wrapper payloads.',
+    fixSafety: 'manual',
+    provenance: [
+      {
+        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/windows-commands',
+        claim: 'cmd.exe has no touch; typical workarounds are `type nul > file` or copy nul.',
+      },
+    ],
+  },
+  {
+    names: new Set(['touch']),
+    message: () => '`touch` is not available in native Windows npm scripts',
+    fixSummary: 'create the file from Node or a cross-platform package',
+  },
+);

--- a/src/rules/PS015.ts
+++ b/src/rules/PS015.ts
@@ -2,8 +2,9 @@
  * PS015 — POSIX_CHMOD: `chmod` has no equivalent permission semantics on
  * Windows (neither cmd.exe nor PowerShell).
  */
-import { availabilityRule } from './util';
+
 import type { RuleModule } from './types';
+import { availabilityRule } from './util';
 
 export const PS015: RuleModule = availabilityRule(
   {
@@ -20,14 +21,18 @@ export const PS015: RuleModule = availabilityRule(
     fixSafety: 'manual',
     provenance: [
       {
-        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/icacls',
-        claim: 'Windows ACLs (icacls) differ fundamentally from POSIX mode bits; there is no chmod.',
+        source:
+          'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/icacls',
+        claim:
+          'Windows ACLs (icacls) differ fundamentally from POSIX mode bits; there is no chmod.',
       },
     ],
   },
   {
     names: new Set(['chmod']),
-    message: (cmd) => `\`${cmd.argv[0]?.raw ?? 'chmod'}\` has no equivalent permission semantics on Windows`,
-    fixSummary: 'avoid chmod in lifecycle scripts; set executability in packaging (e.g. npm bin) instead',
+    message: (cmd) =>
+      `\`${cmd.argv[0]?.raw ?? 'chmod'}\` has no equivalent permission semantics on Windows`,
+    fixSummary:
+      'avoid chmod in lifecycle scripts; set executability in packaging (e.g. npm bin) instead',
   },
 );

--- a/src/rules/PS015.ts
+++ b/src/rules/PS015.ts
@@ -1,0 +1,33 @@
+/**
+ * PS015 — POSIX_CHMOD: `chmod` has no equivalent permission semantics on
+ * Windows (neither cmd.exe nor PowerShell).
+ */
+import { availabilityRule } from './util';
+import type { RuleModule } from './types';
+
+export const PS015: RuleModule = availabilityRule(
+  {
+    id: 'PS015',
+    title: 'POSIX_CHMOD',
+    summary: 'chmod permission bits have no Windows equivalent; avoid relying on chmod in scripts.',
+    severity: 'warn',
+    confidence: 'high',
+    affectedTargets: ['cmd', 'powershell'],
+    badExamples: ['chmod +x scripts/deploy.sh', 'chmod 755 build'],
+    goodExamples: ['node scripts/deploy.js', 'deploy-now --target production'],
+    falsePositiveNotes:
+      'Legitimate inside explicit bash wrappers (not re-analyzed). Postinstall use of chmod for optionalDependencies executables is a known pattern — suppress via config when intentional.',
+    fixSafety: 'manual',
+    provenance: [
+      {
+        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/icacls',
+        claim: 'Windows ACLs (icacls) differ fundamentally from POSIX mode bits; there is no chmod.',
+      },
+    ],
+  },
+  {
+    names: new Set(['chmod']),
+    message: (cmd) => `\`${cmd.argv[0]?.raw ?? 'chmod'}\` has no equivalent permission semantics on Windows`,
+    fixSummary: 'avoid chmod in lifecycle scripts; set executability in packaging (e.g. npm bin) instead',
+  },
+);

--- a/src/rules/PS016.ts
+++ b/src/rules/PS016.ts
@@ -1,0 +1,34 @@
+/**
+ * PS016 — POSIX_WHICH: `which` does not exist under cmd.exe (it uses `where`).
+ */
+import { availabilityRule } from './util';
+import type { RuleModule } from './types';
+
+export const PS016: RuleModule = availabilityRule(
+  {
+    id: 'PS016',
+    title: 'POSIX_WHICH',
+    summary: '`which` is not available in native Windows npm scripts (cmd.exe uses `where`).',
+    severity: 'error',
+    confidence: 'high',
+    affectedTargets: ['cmd'],
+    badExamples: ['which node', 'which python3'],
+    goodExamples: [
+      'node -e "console.log(process.execPath)"',
+      'npx which-node',
+    ],
+    falsePositiveNotes: 'PowerShell users often alias which; the default npm script shell on Windows is cmd.exe, which has where.exe only.',
+    fixSafety: 'manual',
+    provenance: [
+      {
+        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/where',
+        claim: 'cmd.exe ships where.exe; there is no which.',
+      },
+    ],
+  },
+  {
+    names: new Set(['which']),
+    message: () => '`which` is not available in native Windows npm scripts (use `where` or Node lookups)',
+    fixSummary: 'use where on Windows, a cross-platform lookup package, or Node resolution',
+  },
+);

--- a/src/rules/PS016.ts
+++ b/src/rules/PS016.ts
@@ -1,8 +1,9 @@
 /**
  * PS016 — POSIX_WHICH: `which` does not exist under cmd.exe (it uses `where`).
  */
-import { availabilityRule } from './util';
+
 import type { RuleModule } from './types';
+import { availabilityRule } from './util';
 
 export const PS016: RuleModule = availabilityRule(
   {
@@ -13,22 +14,22 @@ export const PS016: RuleModule = availabilityRule(
     confidence: 'high',
     affectedTargets: ['cmd'],
     badExamples: ['which node', 'which python3'],
-    goodExamples: [
-      'node -e "console.log(process.execPath)"',
-      'npx which-node',
-    ],
-    falsePositiveNotes: 'PowerShell users often alias which; the default npm script shell on Windows is cmd.exe, which has where.exe only.',
+    goodExamples: ['node -e "console.log(process.execPath)"', 'npx which-node'],
+    falsePositiveNotes:
+      'PowerShell users often alias which; the default npm script shell on Windows is cmd.exe, which has where.exe only.',
     fixSafety: 'manual',
     provenance: [
       {
-        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/where',
+        source:
+          'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/where',
         claim: 'cmd.exe ships where.exe; there is no which.',
       },
     ],
   },
   {
     names: new Set(['which']),
-    message: () => '`which` is not available in native Windows npm scripts (use `where` or Node lookups)',
+    message: () =>
+      '`which` is not available in native Windows npm scripts (use `where` or Node lookups)',
     fixSummary: 'use where on Windows, a cross-platform lookup package, or Node resolution',
   },
 );

--- a/src/rules/PS017.ts
+++ b/src/rules/PS017.ts
@@ -1,8 +1,9 @@
 /**
  * PS017 — POSIX_GREP: `grep` does not exist under cmd.exe.
  */
-import { availabilityRule } from './util';
+
 import type { RuleModule } from './types';
+import { availabilityRule } from './util';
 
 export const PS017: RuleModule = availabilityRule(
   {
@@ -18,7 +19,8 @@ export const PS017: RuleModule = availabilityRule(
     fixSafety: 'conditional',
     provenance: [
       {
-        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/findstr',
+        source:
+          'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/findstr',
         claim: 'cmd.exe ships findstr, not grep.',
       },
     ],

--- a/src/rules/PS017.ts
+++ b/src/rules/PS017.ts
@@ -1,0 +1,31 @@
+/**
+ * PS017 — POSIX_GREP: `grep` does not exist under cmd.exe.
+ */
+import { availabilityRule } from './util';
+import type { RuleModule } from './types';
+
+export const PS017: RuleModule = availabilityRule(
+  {
+    id: 'PS017',
+    title: 'POSIX_GREP',
+    summary: '`grep` is not available in native Windows npm scripts.',
+    severity: 'warn',
+    confidence: 'high',
+    affectedTargets: ['cmd'],
+    badExamples: ['grep -r "TODO" src', 'cat x | grep y'],
+    goodExamples: ['shx grep -r "TODO" src', 'node scripts/search.js'],
+    falsePositiveNotes: 'Not reported for `shx grep …` or grep inside strings/wrapper payloads.',
+    fixSafety: 'conditional',
+    provenance: [
+      {
+        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/findstr',
+        claim: 'cmd.exe ships findstr, not grep.',
+      },
+    ],
+  },
+  {
+    names: new Set(['grep']),
+    message: () => '`grep` is not available in native Windows npm scripts (findstr differs)',
+    fixSummary: 'use shx grep or a Node implementation',
+  },
+);

--- a/src/rules/PS018.ts
+++ b/src/rules/PS018.ts
@@ -1,8 +1,9 @@
 /**
  * PS018 — POSIX_SED: `sed` does not exist under cmd.exe.
  */
-import { availabilityRule } from './util';
+
 import type { RuleModule } from './types';
+import { availabilityRule } from './util';
 
 export const PS018: RuleModule = availabilityRule(
   {
@@ -18,7 +19,8 @@ export const PS018: RuleModule = availabilityRule(
     fixSafety: 'conditional',
     provenance: [
       {
-        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/windows-commands',
+        source:
+          'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/windows-commands',
         claim: 'cmd.exe ships no sed equivalent.',
       },
     ],

--- a/src/rules/PS018.ts
+++ b/src/rules/PS018.ts
@@ -1,0 +1,31 @@
+/**
+ * PS018 — POSIX_SED: `sed` does not exist under cmd.exe.
+ */
+import { availabilityRule } from './util';
+import type { RuleModule } from './types';
+
+export const PS018: RuleModule = availabilityRule(
+  {
+    id: 'PS018',
+    title: 'POSIX_SED',
+    summary: '`sed` is not available in native Windows npm scripts.',
+    severity: 'warn',
+    confidence: 'high',
+    affectedTargets: ['cmd'],
+    badExamples: ["sed -i 's/foo/bar/' file.txt", "sed 's/a/b/g' x > y"],
+    goodExamples: ['node scripts/replace.js', 'shx sed "s/a/b/g" x'],
+    falsePositiveNotes: 'Not reported for `shx sed …` or sed inside strings/wrapper payloads.',
+    fixSafety: 'conditional',
+    provenance: [
+      {
+        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/windows-commands',
+        claim: 'cmd.exe ships no sed equivalent.',
+      },
+    ],
+  },
+  {
+    names: new Set(['sed']),
+    message: () => '`sed` is not available in native Windows npm scripts',
+    fixSummary: 'move the transformation into a Node script or use shx sed',
+  },
+);

--- a/src/rules/PS019.ts
+++ b/src/rules/PS019.ts
@@ -1,8 +1,9 @@
 /**
  * PS019 — POSIX_CAT: `cat` does not exist under cmd.exe (type differs).
  */
-import { availabilityRule } from './util';
+
 import type { RuleModule } from './types';
+import { availabilityRule } from './util';
 
 export const PS019: RuleModule = availabilityRule(
   {
@@ -13,12 +14,17 @@ export const PS019: RuleModule = availabilityRule(
     confidence: 'high',
     affectedTargets: ['cmd'],
     badExamples: ['cat config/base.json > config/local.json', 'cat CHANGELOG.md | head -5'],
-    goodExamples: ['shx cat config/base.json', 'node -e "process.stdout.write(require(\'fs\').readFileSync(\'f\'))"'],
-    falsePositiveNotes: 'PowerShell has a cat alias, but the default Windows npm script shell is cmd.exe (type). Not reported for `shx cat …`.',
+    goodExamples: [
+      'shx cat config/base.json',
+      "node -e \"process.stdout.write(require('fs').readFileSync('f'))\"",
+    ],
+    falsePositiveNotes:
+      'PowerShell has a cat alias, but the default Windows npm script shell is cmd.exe (type). Not reported for `shx cat …`.',
     fixSafety: 'conditional',
     provenance: [
       {
-        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/type',
+        source:
+          'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/type',
         claim: 'cmd.exe uses type; cat is not recognized.',
       },
     ],

--- a/src/rules/PS019.ts
+++ b/src/rules/PS019.ts
@@ -1,0 +1,31 @@
+/**
+ * PS019 — POSIX_CAT: `cat` does not exist under cmd.exe (type differs).
+ */
+import { availabilityRule } from './util';
+import type { RuleModule } from './types';
+
+export const PS019: RuleModule = availabilityRule(
+  {
+    id: 'PS019',
+    title: 'POSIX_CAT',
+    summary: '`cat` is not available in native Windows npm scripts.',
+    severity: 'warn',
+    confidence: 'high',
+    affectedTargets: ['cmd'],
+    badExamples: ['cat config/base.json > config/local.json', 'cat CHANGELOG.md | head -5'],
+    goodExamples: ['shx cat config/base.json', 'node -e "process.stdout.write(require(\'fs\').readFileSync(\'f\'))"'],
+    falsePositiveNotes: 'PowerShell has a cat alias, but the default Windows npm script shell is cmd.exe (type). Not reported for `shx cat …`.',
+    fixSafety: 'conditional',
+    provenance: [
+      {
+        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/type',
+        claim: 'cmd.exe uses type; cat is not recognized.',
+      },
+    ],
+  },
+  {
+    names: new Set(['cat']),
+    message: () => '`cat` is not available in native Windows npm scripts',
+    fixSummary: 'use shx cat or Node fs',
+  },
+);

--- a/src/rules/PS020.ts
+++ b/src/rules/PS020.ts
@@ -1,0 +1,53 @@
+/**
+ * PS020 — COMMAND_SUBSTITUTION: `$(…)` is POSIX command substitution; cmd.exe
+ * cannot execute it.
+ */
+import { makeFinding } from '../core/finding';
+import { commandsOf } from './util';
+import type { Finding, RuleContext, RuleModule } from './types';
+
+export const PS020: RuleModule = {
+  id: 'PS020',
+  title: 'COMMAND_SUBSTITUTION',
+  summary: '`$(…)` command substitution is POSIX-only and fails under cmd.exe.',
+  severity: 'error',
+  confidence: 'high',
+  affectedTargets: ['cmd'],
+  badExamples: ['node $(npm bin)/jest', 'echo "built at $(date)"', 'rm -rf $(ls dist)'],
+  goodExamples: ['npx jest', 'node scripts/run.js'],
+  falsePositiveNotes:
+    'Not reported inside explicit shell wrappers (PS030 owns those), and substitution contents are not scanned for other rules (no double reporting).',
+  fixSafety: 'manual',
+  provenance: [
+    {
+      source: 'https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_03',
+      claim: '$( ) command substitution is defined by POSIX shell.',
+    },
+    {
+      source: 'https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/cc772390(v=ws.11)',
+      claim: 'cmd.exe has no command substitution; it uses for /f with delayed expansion at best.',
+    },
+  ],
+  check(ir, ctx: RuleContext): Finding[] {
+    const findings: Finding[] = [];
+    for (const cmd of commandsOf(ir)) {
+      const tokens = [...cmd.argv, ...cmd.redirects.flatMap((r) => (r.target !== null ? [r.target] : []))];
+      for (const tok of tokens) {
+        for (const exp of tok.expansions) {
+          if (exp.kind !== 'command') continue;
+          const finding = makeFinding(this, ctx, {
+            message: `\`${exp.raw}\` is POSIX command substitution; cmd.exe cannot run it`,
+            span: exp.span,
+            fix: {
+              ruleId: this.id,
+              safety: 'manual',
+              description: 'compute the value in a Node helper or run the step inside an explicit shell',
+            },
+          });
+          if (finding !== null) findings.push(finding);
+        }
+      }
+    }
+    return findings;
+  },
+};

--- a/src/rules/PS020.ts
+++ b/src/rules/PS020.ts
@@ -3,8 +3,8 @@
  * cannot execute it.
  */
 import { makeFinding } from '../core/finding';
-import { commandsOf } from './util';
 import type { Finding, RuleContext, RuleModule } from './types';
+import { commandsOf } from './util';
 
 export const PS020: RuleModule = {
   id: 'PS020',
@@ -20,18 +20,23 @@ export const PS020: RuleModule = {
   fixSafety: 'manual',
   provenance: [
     {
-      source: 'https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_03',
+      source:
+        'https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_03',
       claim: '$( ) command substitution is defined by POSIX shell.',
     },
     {
-      source: 'https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/cc772390(v=ws.11)',
+      source:
+        'https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/cc772390(v=ws.11)',
       claim: 'cmd.exe has no command substitution; it uses for /f with delayed expansion at best.',
     },
   ],
   check(ir, ctx: RuleContext): Finding[] {
     const findings: Finding[] = [];
     for (const cmd of commandsOf(ir)) {
-      const tokens = [...cmd.argv, ...cmd.redirects.flatMap((r) => (r.target !== null ? [r.target] : []))];
+      const tokens = [
+        ...cmd.argv,
+        ...cmd.redirects.flatMap((r) => (r.target !== null ? [r.target] : [])),
+      ];
       for (const tok of tokens) {
         for (const exp of tok.expansions) {
           if (exp.kind !== 'command') continue;
@@ -41,7 +46,8 @@ export const PS020: RuleModule = {
             fix: {
               ruleId: this.id,
               safety: 'manual',
-              description: 'compute the value in a Node helper or run the step inside an explicit shell',
+              description:
+                'compute the value in a Node helper or run the step inside an explicit shell',
             },
           });
           if (finding !== null) findings.push(finding);

--- a/src/rules/PS021.ts
+++ b/src/rules/PS021.ts
@@ -1,0 +1,35 @@
+/**
+ * PS021 — POSIX_EXPORT: `export` is a POSIX shell builtin; cmd.exe uses `set`.
+ */
+import { availabilityRule } from './util';
+import type { RuleModule } from './types';
+
+export const PS021: RuleModule = availabilityRule(
+  {
+    id: 'PS021',
+    title: 'POSIX_EXPORT',
+    summary: '`export` is a POSIX shell builtin and fails under cmd.exe.',
+    severity: 'error',
+    confidence: 'high',
+    affectedTargets: ['cmd'],
+    badExamples: ['export NODE_ENV=production', 'export PATH=$PATH:./bin'],
+    goodExamples: ['cross-env NODE_ENV=production node app.js', 'node run-with-env.js'],
+    falsePositiveNotes: 'Not reported inside explicit shell wrappers.',
+    fixSafety: 'conditional',
+    provenance: [
+      {
+        source: 'https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#export',
+        claim: 'export marks variables for the environment — a POSIX builtin.',
+      },
+      {
+        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/set_1',
+        claim: 'cmd.exe uses `set` to define session variables; `export` is not recognized.',
+      },
+    ],
+  },
+  {
+    names: new Set(['export']),
+    message: () => '`export` is a POSIX shell builtin with no cmd.exe equivalent',
+    fixSummary: 'use cross-env per command, or set the variable in a Node wrapper',
+  },
+);

--- a/src/rules/PS021.ts
+++ b/src/rules/PS021.ts
@@ -1,8 +1,9 @@
 /**
  * PS021 — POSIX_EXPORT: `export` is a POSIX shell builtin; cmd.exe uses `set`.
  */
-import { availabilityRule } from './util';
+
 import type { RuleModule } from './types';
+import { availabilityRule } from './util';
 
 export const PS021: RuleModule = availabilityRule(
   {
@@ -22,7 +23,8 @@ export const PS021: RuleModule = availabilityRule(
         claim: 'export marks variables for the environment — a POSIX builtin.',
       },
       {
-        source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/set_1',
+        source:
+          'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/set_1',
         claim: 'cmd.exe uses `set` to define session variables; `export` is not recognized.',
       },
     ],

--- a/src/rules/PS022.ts
+++ b/src/rules/PS022.ts
@@ -1,9 +1,10 @@
 /**
  * PS022 — POSIX_SOURCE: `source` / `.` dot-sourcing requires a POSIX shell.
  */
-import { availabilityRule } from './util';
+
 import type { CommandNode } from '../parser/ir';
 import type { RuleModule } from './types';
+import { availabilityRule } from './util';
 
 function isSourceInvocation(cmd: CommandNode): boolean {
   const name = cmd.argv[0]?.value ?? '';
@@ -20,12 +21,14 @@ export const PS022: RuleModule = availabilityRule(
     affectedTargets: ['cmd', 'powershell'],
     badExamples: ['source ./env.sh', '. ./scripts/env.sh'],
     goodExamples: ['node -r dotenv/config app.js', 'bash ./env.sh'],
-    falsePositiveNotes: 'Only the dot form with a following argument counts; a bare `.` is not a source command.',
+    falsePositiveNotes:
+      'Only the dot form with a following argument counts; a bare `.` is not a source command.',
     fixSafety: 'manual',
     provenance: [
       {
         source: 'https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#dot',
-        claim: '`.` (dot) executes a file in the current shell — POSIX builtin; source is the bash synonym.',
+        claim:
+          '`.` (dot) executes a file in the current shell — POSIX builtin; source is the bash synonym.',
       },
     ],
   },

--- a/src/rules/PS022.ts
+++ b/src/rules/PS022.ts
@@ -1,0 +1,38 @@
+/**
+ * PS022 — POSIX_SOURCE: `source` / `.` dot-sourcing requires a POSIX shell.
+ */
+import { availabilityRule } from './util';
+import type { CommandNode } from '../parser/ir';
+import type { RuleModule } from './types';
+
+function isSourceInvocation(cmd: CommandNode): boolean {
+  const name = cmd.argv[0]?.value ?? '';
+  return name === 'source' || (name === '.' && cmd.argv.length > 1);
+}
+
+export const PS022: RuleModule = availabilityRule(
+  {
+    id: 'PS022',
+    title: 'POSIX_SOURCE',
+    summary: '`source` (or `.`) requires a POSIX shell and fails under cmd.exe.',
+    severity: 'error',
+    confidence: 'high',
+    affectedTargets: ['cmd', 'powershell'],
+    badExamples: ['source ./env.sh', '. ./scripts/env.sh'],
+    goodExamples: ['node -r dotenv/config app.js', 'bash ./env.sh'],
+    falsePositiveNotes: 'Only the dot form with a following argument counts; a bare `.` is not a source command.',
+    fixSafety: 'manual',
+    provenance: [
+      {
+        source: 'https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#dot',
+        claim: '`.` (dot) executes a file in the current shell — POSIX builtin; source is the bash synonym.',
+      },
+    ],
+  },
+  {
+    names: new Set(['source', '.']),
+    matches: isSourceInvocation,
+    message: () => '`source`/`.` dot-sourcing requires a POSIX shell',
+    fixSummary: 'move environment setup into Node (dotenv) or an explicit shell wrapper',
+  },
+);

--- a/src/rules/PS023.ts
+++ b/src/rules/PS023.ts
@@ -3,8 +3,8 @@
  * are literal text under cmd.exe (`%VAR%` there).
  */
 import { makeFinding } from '../core/finding';
-import { commandsOf } from './util';
 import type { Finding, RuleContext, RuleModule } from './types';
+import { commandsOf } from './util';
 
 export const PS023: RuleModule = {
   id: 'PS023',
@@ -20,18 +20,23 @@ export const PS023: RuleModule = {
   fixSafety: 'manual',
   provenance: [
     {
-      source: 'https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_05_02',
+      source:
+        'https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_05_02',
       claim: 'POSIX shells expand $VAR/${VAR}.',
     },
     {
-      source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/set_1',
+      source:
+        'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/set_1',
       claim: 'cmd.exe expands %VAR%; $VAR stays literal.',
     },
   ],
   check(ir, ctx: RuleContext): Finding[] {
     const findings: Finding[] = [];
     for (const cmd of commandsOf(ir)) {
-      const tokens = [...cmd.argv, ...cmd.redirects.flatMap((r) => (r.target !== null ? [r.target] : []))];
+      const tokens = [
+        ...cmd.argv,
+        ...cmd.redirects.flatMap((r) => (r.target !== null ? [r.target] : [])),
+      ];
       for (const tok of tokens) {
         if (tok.value.startsWith('$env:')) continue; // PS003
         for (const exp of tok.expansions) {

--- a/src/rules/PS023.ts
+++ b/src/rules/PS023.ts
@@ -1,0 +1,54 @@
+/**
+ * PS023 — POSIX_VAR_EXPANSION: `$VAR` / `${VAR}` expand in POSIX shells but
+ * are literal text under cmd.exe (`%VAR%` there).
+ */
+import { makeFinding } from '../core/finding';
+import { commandsOf } from './util';
+import type { Finding, RuleContext, RuleModule } from './types';
+
+export const PS023: RuleModule = {
+  id: 'PS023',
+  title: 'POSIX_VAR_EXPANSION',
+  summary: '`$VAR` / `${VAR}` do not expand under cmd.exe (which uses `%VAR%`).',
+  severity: 'warn',
+  confidence: 'medium',
+  affectedTargets: ['cmd'],
+  badExamples: ['echo $npm_package_version', 'node build.js --out ${OUT_DIR:-dist}', 'ls $HOME'],
+  goodExamples: ['node -e "console.log(process.env.npm_package_version)"', 'npm run print-version'],
+  falsePositiveNotes:
+    'Medium confidence by design: cmd users may run via a custom script-shell, and npm_* variables are sometimes only needed on Unix. `$env:` forms belong to PS003; `$(…)` to PS020.',
+  fixSafety: 'manual',
+  provenance: [
+    {
+      source: 'https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_05_02',
+      claim: 'POSIX shells expand $VAR/${VAR}.',
+    },
+    {
+      source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/set_1',
+      claim: 'cmd.exe expands %VAR%; $VAR stays literal.',
+    },
+  ],
+  check(ir, ctx: RuleContext): Finding[] {
+    const findings: Finding[] = [];
+    for (const cmd of commandsOf(ir)) {
+      const tokens = [...cmd.argv, ...cmd.redirects.flatMap((r) => (r.target !== null ? [r.target] : []))];
+      for (const tok of tokens) {
+        if (tok.value.startsWith('$env:')) continue; // PS003
+        for (const exp of tok.expansions) {
+          if (exp.kind !== 'var' && exp.kind !== 'braced' && exp.kind !== 'special') continue;
+          const finding = makeFinding(this, ctx, {
+            message: `\`${exp.raw}\` does not expand under cmd.exe (it uses %VAR%)`,
+            span: exp.span,
+            fix: {
+              ruleId: this.id,
+              safety: 'manual',
+              description: 'use cross-env-shell, a Node wrapper, or per-shell scripts',
+            },
+          });
+          if (finding !== null) findings.push(finding);
+        }
+      }
+    }
+    return findings;
+  },
+};

--- a/src/rules/PS024.ts
+++ b/src/rules/PS024.ts
@@ -1,0 +1,52 @@
+/**
+ * PS024 — CMD_VAR_EXPANSION: `%VAR%` is cmd.exe-specific; POSIX sh passes it
+ * through literally.
+ */
+import { makeFinding } from '../core/finding';
+import { commandsOf } from './util';
+import type { Finding, RuleContext, RuleModule } from './types';
+
+export const PS024: RuleModule = {
+  id: 'PS024',
+  title: 'CMD_VAR_EXPANSION',
+  summary: '`%VAR%` expansion is cmd.exe-specific and stays literal in POSIX sh.',
+  severity: 'warn',
+  confidence: 'high',
+  affectedTargets: ['posix-sh'],
+  badExamples: ['echo %APPDATA%', 'mkdir "%USERPROFILE%\\build"'],
+  goodExamples: ['echo $HOME', 'node -e "console.log(process.env.USERPROFILE)"'],
+  falsePositiveNotes:
+    'Format strings without a closing percent (printf "%s\\n", date +%Y) never match. cmd-style FOR variables (%%i) are out of scope for v0.1.',
+  fixSafety: 'manual',
+  provenance: [
+    {
+      source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/set_1',
+      claim: 'cmd.exe expands %VAR%.',
+    },
+    {
+      source: 'https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html',
+      claim: 'POSIX sh treats % as a literal character.',
+    },
+  ],
+  check(ir, ctx: RuleContext): Finding[] {
+    const findings: Finding[] = [];
+    for (const cmd of commandsOf(ir)) {
+      for (const tok of cmd.argv) {
+        for (const exp of tok.expansions) {
+          if (exp.kind !== 'cmdvar') continue;
+          const finding = makeFinding(this, ctx, {
+            message: `\`${exp.raw}\` is cmd.exe-specific; POSIX sh leaves it literal`,
+            span: exp.span,
+            fix: {
+              ruleId: this.id,
+              safety: 'manual',
+              description: 'read the variable in Node (process.env) or use per-shell scripts',
+            },
+          });
+          if (finding !== null) findings.push(finding);
+        }
+      }
+    }
+    return findings;
+  },
+};

--- a/src/rules/PS024.ts
+++ b/src/rules/PS024.ts
@@ -3,8 +3,8 @@
  * through literally.
  */
 import { makeFinding } from '../core/finding';
-import { commandsOf } from './util';
 import type { Finding, RuleContext, RuleModule } from './types';
+import { commandsOf } from './util';
 
 export const PS024: RuleModule = {
   id: 'PS024',
@@ -20,7 +20,8 @@ export const PS024: RuleModule = {
   fixSafety: 'manual',
   provenance: [
     {
-      source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/set_1',
+      source:
+        'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/set_1',
       claim: 'cmd.exe expands %VAR%.',
     },
     {

--- a/src/rules/PS025.ts
+++ b/src/rules/PS025.ts
@@ -1,0 +1,48 @@
+/**
+ * PS025 — DEV_NULL: `/dev/null` does not exist on Windows (`NUL` there).
+ */
+import { makeFinding } from '../core/finding';
+import { commandsOf } from './util';
+import type { Finding, RuleContext, RuleModule } from './types';
+
+export const PS025: RuleModule = {
+  id: 'PS025',
+  title: 'DEV_NULL',
+  summary: 'Redirecting to /dev/null fails on Windows (the device is NUL).',
+  severity: 'warn',
+  confidence: 'high',
+  affectedTargets: ['cmd', 'powershell'],
+  badExamples: ['node heavy.js > /dev/null', 'cmd 2> /dev/null'],
+  goodExamples: ['node scripts/quiet.js', 'node heavy.js > build.log'],
+  falsePositiveNotes: 'Only tokens equal to /dev/null (or a /dev/null path suffix) match; documentation strings mentioning /dev/null inside larger quoted prose are still reported — suppress via config if intentional.',
+  fixSafety: 'manual',
+  provenance: [
+    {
+      source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/microsoft-windows-commands',
+      claim: 'Windows null device is NUL; /dev/null does not resolve.',
+    },
+  ],
+  check(ir, ctx: RuleContext): Finding[] {
+    const findings: Finding[] = [];
+    const check = (value: string, span: [number, number]): void => {
+      if (!value.includes('/dev/null')) return;
+      const finding = makeFinding(this, ctx, {
+        message: '`/dev/null` does not exist on Windows (the null device is `NUL`)',
+        span,
+        fix: {
+          ruleId: this.id,
+          safety: 'manual',
+          description: 'use a cross-platform redirection strategy (Node wrapper or per-shell scripts)',
+        },
+      });
+      if (finding !== null) findings.push(finding);
+    };
+    for (const cmd of commandsOf(ir)) {
+      for (const tok of cmd.argv) check(tok.value, tok.span);
+      for (const red of cmd.redirects) {
+        if (red.target !== null) check(red.target.value, red.target.span);
+      }
+    }
+    return findings;
+  },
+};

--- a/src/rules/PS025.ts
+++ b/src/rules/PS025.ts
@@ -2,8 +2,8 @@
  * PS025 — DEV_NULL: `/dev/null` does not exist on Windows (`NUL` there).
  */
 import { makeFinding } from '../core/finding';
-import { commandsOf } from './util';
 import type { Finding, RuleContext, RuleModule } from './types';
+import { commandsOf } from './util';
 
 export const PS025: RuleModule = {
   id: 'PS025',
@@ -14,11 +14,13 @@ export const PS025: RuleModule = {
   affectedTargets: ['cmd', 'powershell'],
   badExamples: ['node heavy.js > /dev/null', 'cmd 2> /dev/null'],
   goodExamples: ['node scripts/quiet.js', 'node heavy.js > build.log'],
-  falsePositiveNotes: 'Only tokens equal to /dev/null (or a /dev/null path suffix) match; documentation strings mentioning /dev/null inside larger quoted prose are still reported — suppress via config if intentional.',
+  falsePositiveNotes:
+    'Only tokens equal to /dev/null (or a /dev/null path suffix) match; documentation strings mentioning /dev/null inside larger quoted prose are still reported — suppress via config if intentional.',
   fixSafety: 'manual',
   provenance: [
     {
-      source: 'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/microsoft-windows-commands',
+      source:
+        'https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/microsoft-windows-commands',
       claim: 'Windows null device is NUL; /dev/null does not resolve.',
     },
   ],
@@ -32,7 +34,8 @@ export const PS025: RuleModule = {
         fix: {
           ruleId: this.id,
           safety: 'manual',
-          description: 'use a cross-platform redirection strategy (Node wrapper or per-shell scripts)',
+          description:
+            'use a cross-platform redirection strategy (Node wrapper or per-shell scripts)',
         },
       });
       if (finding !== null) findings.push(finding);

--- a/src/rules/PS026.ts
+++ b/src/rules/PS026.ts
@@ -1,0 +1,52 @@
+/**
+ * PS026 — UNIX_PATH_ASSUMPTION: hardcoded Unix paths (/tmp, /usr/bin, …)
+ * rarely exist on Windows.
+ */
+import { makeFinding } from '../core/finding';
+import { commandsOf } from './util';
+import type { Finding, RuleContext, RuleModule } from './types';
+
+const UNIX_PATH_PREFIXES = ['/tmp', '/usr', '/var', '/etc', '/opt', '/home', '/bin', '/sbin', '/lib'];
+
+export const PS026: RuleModule = {
+  id: 'PS026',
+  title: 'UNIX_PATH_ASSUMPTION',
+  summary: 'Hardcoded Unix paths (/tmp, /usr/bin, …) do not exist on Windows.',
+  severity: 'advisory',
+  confidence: 'medium',
+  affectedTargets: ['cmd', 'powershell'],
+  badExamples: ['cp x /tmp/', 'mkdir /usr/local/etc/app'],
+  goodExamples: ['mktemp -d', 'node scripts/tmpdir.js'],
+  falsePositiveNotes:
+    'Advisory only: absolute Unix paths are occasionally passed as opaque arguments to tools that interpret them elsewhere. Paths like /api used as URLs must not match (they do not: prefix list covers filesystem roots only).',
+  fixSafety: 'manual',
+  provenance: [
+    {
+      source: 'https://learn.microsoft.com/en-us/windows/deployment/usmt/usmt-recognized-environment-variables',
+      claim: 'Windows has no /tmp or /usr; equivalents live under %TEMP%, %ProgramFiles%.',
+    },
+  ],
+  check(ir, ctx: RuleContext): Finding[] {
+    const findings: Finding[] = [];
+    for (const cmd of commandsOf(ir)) {
+      for (const tok of cmd.argv) {
+        const value = tok.value;
+        const hit = UNIX_PATH_PREFIXES.find(
+          (p) => value === p || value.startsWith(`${p}/`),
+        );
+        if (hit === undefined) continue;
+        const finding = makeFinding(this, ctx, {
+          message: `\`${value}\` assumes a Unix filesystem layout`,
+          span: tok.span,
+          fix: {
+            ruleId: this.id,
+            safety: 'manual',
+            description: 'use os.tmpdir()/PATH lookup in a Node helper instead of hardcoded paths',
+          },
+        });
+        if (finding !== null) findings.push(finding);
+      }
+    }
+    return findings;
+  },
+};

--- a/src/rules/PS026.ts
+++ b/src/rules/PS026.ts
@@ -3,10 +3,20 @@
  * rarely exist on Windows.
  */
 import { makeFinding } from '../core/finding';
-import { commandsOf } from './util';
 import type { Finding, RuleContext, RuleModule } from './types';
+import { commandsOf } from './util';
 
-const UNIX_PATH_PREFIXES = ['/tmp', '/usr', '/var', '/etc', '/opt', '/home', '/bin', '/sbin', '/lib'];
+const UNIX_PATH_PREFIXES = [
+  '/tmp',
+  '/usr',
+  '/var',
+  '/etc',
+  '/opt',
+  '/home',
+  '/bin',
+  '/sbin',
+  '/lib',
+];
 
 export const PS026: RuleModule = {
   id: 'PS026',
@@ -22,7 +32,8 @@ export const PS026: RuleModule = {
   fixSafety: 'manual',
   provenance: [
     {
-      source: 'https://learn.microsoft.com/en-us/windows/deployment/usmt/usmt-recognized-environment-variables',
+      source:
+        'https://learn.microsoft.com/en-us/windows/deployment/usmt/usmt-recognized-environment-variables',
       claim: 'Windows has no /tmp or /usr; equivalents live under %TEMP%, %ProgramFiles%.',
     },
   ],
@@ -31,9 +42,7 @@ export const PS026: RuleModule = {
     for (const cmd of commandsOf(ir)) {
       for (const tok of cmd.argv) {
         const value = tok.value;
-        const hit = UNIX_PATH_PREFIXES.find(
-          (p) => value === p || value.startsWith(`${p}/`),
-        );
+        const hit = UNIX_PATH_PREFIXES.find((p) => value === p || value.startsWith(`${p}/`));
         if (hit === undefined) continue;
         const finding = makeFinding(this, ctx, {
           message: `\`${value}\` assumes a Unix filesystem layout`,

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -3,10 +3,10 @@
  * each rule, applies config severity overrides, filters by active targets
  * and (optionally) by rule id, and returns deterministic sorted findings.
  */
-import { parseScript } from '../parser/parse';
+
 import { sortFindings } from '../core/finding';
-import type { Finding, RuleContext, RuleModule, Severity } from './types';
 import type { ShellTarget } from '../parser/ir';
+import { parseScript } from '../parser/parse';
 import { PS001 } from './PS001';
 import { PS002 } from './PS002';
 import { PS003 } from './PS003';
@@ -30,6 +30,7 @@ import { PS026 } from './PS026';
 import { PS030 } from './PS030';
 import { PS031 } from './PS031';
 import { PS032 } from './PS032';
+import type { Finding, RuleContext, RuleModule, Severity } from './types';
 
 export const RULES: readonly RuleModule[] = [
   PS001,
@@ -69,7 +70,11 @@ export interface RunOptions {
 }
 
 /** Analyze one script string and return findings for the active targets. */
-export function analyzeScript(script: string, ctx: RuleContext, options: RunOptions = {}): Finding[] {
+export function analyzeScript(
+  script: string,
+  ctx: RuleContext,
+  options: RunOptions = {},
+): Finding[] {
   const ir = parseScript(script);
   const findings: Finding[] = [];
   for (const rule of RULES) {
@@ -82,5 +87,4 @@ export function analyzeScript(script: string, ctx: RuleContext, options: RunOpti
   return sortFindings(findings);
 }
 
-export type { Finding, RuleContext, RuleModule, Severity };
-export type { ShellTarget };
+export type { Finding, RuleContext, RuleModule, Severity, ShellTarget };

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -3,19 +3,59 @@
  * each rule, applies config severity overrides, filters by active targets
  * and (optionally) by rule id, and returns deterministic sorted findings.
  */
-
-import { sortFindings } from '../core/finding';
-import type { ShellTarget } from '../parser/ir';
 import { parseScript } from '../parser/parse';
+import { sortFindings } from '../core/finding';
+import type { Finding, RuleContext, RuleModule, Severity } from './types';
+import type { ShellTarget } from '../parser/ir';
 import { PS001 } from './PS001';
 import { PS002 } from './PS002';
 import { PS003 } from './PS003';
+import { PS010 } from './PS010';
+import { PS011 } from './PS011';
+import { PS012 } from './PS012';
+import { PS013 } from './PS013';
+import { PS014 } from './PS014';
+import { PS015 } from './PS015';
+import { PS016 } from './PS016';
+import { PS017 } from './PS017';
+import { PS018 } from './PS018';
+import { PS019 } from './PS019';
+import { PS020 } from './PS020';
+import { PS021 } from './PS021';
+import { PS022 } from './PS022';
+import { PS023 } from './PS023';
+import { PS024 } from './PS024';
+import { PS025 } from './PS025';
+import { PS026 } from './PS026';
 import { PS030 } from './PS030';
 import { PS031 } from './PS031';
 import { PS032 } from './PS032';
-import type { Finding, RuleContext, RuleModule, Severity } from './types';
 
-export const RULES: readonly RuleModule[] = [PS001, PS002, PS003, PS030, PS031, PS032];
+export const RULES: readonly RuleModule[] = [
+  PS001,
+  PS002,
+  PS003,
+  PS010,
+  PS011,
+  PS012,
+  PS013,
+  PS014,
+  PS015,
+  PS016,
+  PS017,
+  PS018,
+  PS019,
+  PS020,
+  PS021,
+  PS022,
+  PS023,
+  PS024,
+  PS025,
+  PS026,
+  PS030,
+  PS031,
+  PS032,
+];
 
 export function getRule(id: string): RuleModule | undefined {
   return RULES.find((r) => r.id === id);
@@ -29,11 +69,7 @@ export interface RunOptions {
 }
 
 /** Analyze one script string and return findings for the active targets. */
-export function analyzeScript(
-  script: string,
-  ctx: RuleContext,
-  options: RunOptions = {},
-): Finding[] {
+export function analyzeScript(script: string, ctx: RuleContext, options: RunOptions = {}): Finding[] {
   const ir = parseScript(script);
   const findings: Finding[] = [];
   for (const rule of RULES) {
@@ -46,4 +82,5 @@ export function analyzeScript(
   return sortFindings(findings);
 }
 
-export type { Finding, RuleContext, RuleModule, Severity, ShellTarget };
+export type { Finding, RuleContext, RuleModule, Severity };
+export type { ShellTarget };

--- a/tests/rules/ps010-013.test.ts
+++ b/tests/rules/ps010-013.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { ids, only, run } from './helpers';
+
+describe('PS010 POSIX_RM', () => {
+  it('positive: rm in command position', () => {
+    expect(ids(only(run('rm -rf dist'), 'PS010'))).toEqual(['PS010']);
+    expect(only(run('rm -r build'), 'PS010')).toHaveLength(1);
+    expect(only(run('rm temp.log && npm test'), 'PS010')).toHaveLength(1);
+  });
+
+  it('negative: cross-platform replacements and strings', () => {
+    expect(only(run('rimraf dist'), 'PS010')).toEqual([]);
+    expect(only(run('shx rm -rf dist'), 'PS010')).toEqual([]);
+    expect(only(run('echo "rm -rf dist"'), 'PS010')).toEqual([]);
+  });
+
+  it('negative: inside bash wrapper (PS030 owns it)', () => {
+    expect(ids(run('bash -c "rm -rf dist"'))).toEqual(['PS030']);
+  });
+
+  it('error severity, cmd affected', () => {
+    const [f] = only(run('rm -rf dist'), 'PS010');
+    expect(f?.severity).toBe('error');
+    expect(f?.affectedTargets).toEqual(['cmd']);
+  });
+});
+
+describe('PS011 POSIX_CP', () => {
+  it('positive: cp variants', () => {
+    expect(ids(only(run('cp -r src dist'), 'PS011'))).toEqual(['PS011']);
+    expect(only(run('cp a.txt b.txt'), 'PS011')).toHaveLength(1);
+    expect(only(run('cp -r a b && npm test'), 'PS011')).toHaveLength(1);
+  });
+
+  it('negative: shx cp and strings', () => {
+    expect(only(run('shx cp -r src dist'), 'PS011')).toEqual([]);
+    expect(only(run('node -e "console.log(\'cp -r\')"'), 'PS011')).toEqual([]);
+    expect(only(run('vite build'), 'PS011')).toEqual([]);
+  });
+});
+
+describe('PS012 POSIX_MV', () => {
+  it('positive: mv variants', () => {
+    expect(ids(only(run('mv dist build'), 'PS012'))).toEqual(['PS012']);
+    expect(only(run('mv old.json new.json'), 'PS012')).toHaveLength(1);
+    expect(only(run('shx ls && mv a b'), 'PS012')).toHaveLength(1);
+  });
+
+  it('negative: shx mv and unrelated commands', () => {
+    expect(only(run('shx mv dist build'), 'PS012')).toEqual([]);
+    expect(only(run('node app.js'), 'PS012')).toEqual([]);
+    expect(only(run('echo "mv x y"'), 'PS012')).toEqual([]);
+  });
+});
+
+describe('PS013 POSIX_MKDIR_P', () => {
+  it('positive: mkdir -p forms', () => {
+    expect(ids(only(run('mkdir -p dist/assets'), 'PS013'))).toEqual(['PS013']);
+    expect(only(run('mkdir -p a/b/c && npm run build'), 'PS013')).toHaveLength(1);
+    expect(only(run('mkdir --parents x'), 'PS013')).toHaveLength(1);
+  });
+
+  it('negative: plain mkdir exists on cmd too', () => {
+    expect(only(run('mkdir dist'), 'PS013')).toEqual([]);
+    expect(only(run('mkdir src lib'), 'PS013')).toEqual([]);
+  });
+
+  it('negative: shx mkdir and strings', () => {
+    expect(only(run('shx mkdir -p dist'), 'PS013')).toEqual([]);
+    expect(only(run('echo "mkdir -p x"'), 'PS013')).toEqual([]);
+    expect(only(run('vite build'), 'PS013')).toEqual([]);
+  });
+});

--- a/tests/rules/ps014-019.test.ts
+++ b/tests/rules/ps014-019.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { only, run } from './helpers';
+
+describe('PS014 POSIX_TOUCH', () => {
+  it('positive: touch usage', () => {
+    expect(only(run('touch build.timestamp'), 'PS014')).toHaveLength(1);
+    expect(only(run('touch src/generated.ts'), 'PS014')).toHaveLength(1);
+    expect(only(run('mkdir d && touch d/x'), 'PS014')).toHaveLength(1);
+  });
+
+  it('negative: not touch in other positions', () => {
+    expect(only(run('echo "touch x"'), 'PS014')).toEqual([]);
+    expect(only(run('vite build --touch'), 'PS014')).toEqual([]);
+    expect(only(run('node app.js'), 'PS014')).toEqual([]);
+  });
+});
+
+describe('PS015 POSIX_CHMOD', () => {
+  it('positive: chmod usage', () => {
+    expect(only(run('chmod +x scripts/deploy.sh'), 'PS015')).toHaveLength(1);
+    expect(only(run('chmod 755 build'), 'PS015')).toHaveLength(1);
+    expect(only(run('chmod -R 644 lib'), 'PS015')).toHaveLength(1);
+  });
+
+  it('negative: strings and wrappers', () => {
+    expect(only(run('echo "chmod +x x"'), 'PS015')).toEqual([]);
+    expect(only(run('bash -c "chmod +x x"'), 'PS015')).toEqual([]);
+    expect(only(run('node app.js'), 'PS015')).toEqual([]);
+  });
+
+  it('affects cmd and powershell', () => {
+    const [f] = only(run('chmod +x x'), 'PS015');
+    expect(f?.affectedTargets).toEqual(['cmd', 'powershell']);
+    expect(f?.severity).toBe('warn');
+  });
+});
+
+describe('PS016 POSIX_WHICH', () => {
+  it('positive: which usage', () => {
+    expect(only(run('which node'), 'PS016')).toHaveLength(1);
+    expect(only(run('which python3'), 'PS016')).toHaveLength(1);
+    expect(only(run('which pnpm && npm t'), 'PS016')).toHaveLength(1);
+  });
+
+  it('negative: other commands', () => {
+    expect(only(run('node -v'), 'PS016')).toEqual([]);
+    expect(only(run('echo "which node"'), 'PS016')).toEqual([]);
+    expect(only(run('ls'), 'PS016')).toEqual([]);
+  });
+});
+
+describe('PS017 POSIX_GREP', () => {
+  it('positive: grep usage', () => {
+    expect(only(run('grep -r "TODO" src'), 'PS017')).toHaveLength(1);
+    expect(only(run('cat x | grep y'), 'PS017')).toHaveLength(1);
+    expect(only(run('grep -q foo file'), 'PS017')).toHaveLength(1);
+  });
+
+  it('negative: shx grep and strings', () => {
+    expect(only(run('shx grep -r "TODO" src'), 'PS017')).toEqual([]);
+    expect(only(run('echo "grep x"'), 'PS017')).toEqual([]);
+    expect(only(run('node app.js'), 'PS017')).toEqual([]);
+  });
+});
+
+describe('PS018 POSIX_SED', () => {
+  it('positive: sed usage', () => {
+    expect(only(run("sed -i 's/foo/bar/' file.txt"), 'PS018')).toHaveLength(1);
+    expect(only(run("sed 's/a/b/g' x > y"), 'PS018')).toHaveLength(1);
+    expect(only(run("cat c | sed 's/x/y/'"), 'PS018')).toHaveLength(1);
+  });
+
+  it('negative: shx sed and strings', () => {
+    expect(only(run('shx sed "s/a/b/g" x'), 'PS018')).toEqual([]);
+    expect(only(run('echo "sed s/x/y/"'), 'PS018')).toEqual([]);
+    expect(only(run('node scripts/replace.js'), 'PS018')).toEqual([]);
+  });
+});
+
+describe('PS019 POSIX_CAT', () => {
+  it('positive: cat usage', () => {
+    expect(only(run('cat a.json > b.json'), 'PS019')).toHaveLength(1);
+    expect(only(run('cat CHANGELOG.md'), 'PS019')).toHaveLength(1);
+    expect(only(run('cat x | head -5'), 'PS019')).toHaveLength(1);
+  });
+
+  it('negative: shx cat and strings', () => {
+    expect(only(run('shx cat config/base.json'), 'PS019')).toEqual([]);
+    expect(only(run('echo "cat x"'), 'PS019')).toEqual([]);
+    expect(only(run('concat-cli x'), 'PS019')).toEqual([]);
+  });
+});

--- a/tests/rules/ps014-019.test.ts
+++ b/tests/rules/ps014-019.test.ts
@@ -28,10 +28,15 @@ describe('PS015 POSIX_CHMOD', () => {
     expect(only(run('node app.js'), 'PS015')).toEqual([]);
   });
 
-  it('affects cmd and powershell', () => {
+  it('intersects affected targets with the active set (metadata lists both)', () => {
     const [f] = only(run('chmod +x x'), 'PS015');
-    expect(f?.affectedTargets).toEqual(['cmd', 'powershell']);
+    expect(f?.affectedTargets).toEqual(['cmd']); // default targets: posix-sh + cmd
     expect(f?.severity).toBe('warn');
+  });
+
+  it('reports powershell too when it is an active target', () => {
+    const [f] = only(run('chmod +x x', { targets: ['cmd', 'powershell'] }), 'PS015');
+    expect(f?.affectedTargets).toEqual(['cmd', 'powershell']);
   });
 });
 

--- a/tests/rules/ps020-026.test.ts
+++ b/tests/rules/ps020-026.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { ids, only, run } from './helpers';
+
+describe('PS020 COMMAND_SUBSTITUTION', () => {
+  it('positive: $() constructs', () => {
+    expect(ids(only(run('node $(npm bin)/jest'), 'PS020'))).toEqual(['PS020']);
+    expect(only(run('echo "built at $(date)"'), 'PS020')).toHaveLength(1);
+    expect(only(run('rm -rf $(ls dist)'), 'PS020')).toHaveLength(1);
+  });
+
+  it('negative: no substitution', () => {
+    expect(only(run('node app.js'), 'PS020')).toEqual([]);
+    expect(only(run('echo $HOME'), 'PS020')).toEqual([]);
+    expect(only(run('echo "$(pwd)" && npx jest'), 'PS020')).toHaveLength(1); // exactly one, for the one $()
+  });
+
+  it('nested substitution counts once', () => {
+    expect(only(run('echo $(dirname $(pwd))'), 'PS020')).toHaveLength(1);
+  });
+});
+
+describe('PS021 POSIX_EXPORT', () => {
+  it('positive: export statements', () => {
+    expect(only(run('export NODE_ENV=production'), 'PS021')).toHaveLength(1);
+    expect(only(run('export PATH=$PATH:./bin'), 'PS021')).toHaveLength(1);
+    expect(only(run('npm i && export A=1 && node x'), 'PS021')).toHaveLength(1);
+  });
+
+  it('negative: strings and cross-env', () => {
+    expect(only(run('echo "export A=1"'), 'PS021')).toEqual([]);
+    expect(only(run('cross-env NODE_ENV=x node a'), 'PS021')).toEqual([]);
+    expect(only(run('node app.js'), 'PS021')).toEqual([]);
+  });
+});
+
+describe('PS022 POSIX_SOURCE', () => {
+  it('positive: source and dot forms', () => {
+    expect(only(run('source ./env.sh'), 'PS022')).toHaveLength(1);
+    expect(only(run('. ./scripts/env.sh'), 'PS022')).toHaveLength(1);
+    expect(only(run('source env.sh && npm t'), 'PS022')).toHaveLength(1);
+  });
+
+  it('negative: bare dot and unrelated', () => {
+    expect(only(run('node app.js'), 'PS022')).toEqual([]);
+    expect(only(run('echo source'), 'PS022')).toEqual([]);
+    expect(only(run('vite build'), 'PS022')).toEqual([]);
+  });
+});
+
+describe('PS023 POSIX_VAR_EXPANSION', () => {
+  it('positive: $VAR forms', () => {
+    expect(only(run('echo $npm_package_version'), 'PS023')).toHaveLength(1);
+    expect(only(run('node build.js --out ${OUT_DIR:-dist}'), 'PS023')).toHaveLength(1);
+    expect(only(run('ls $HOME'), 'PS023')).toHaveLength(1);
+  });
+
+  it('negative: no dollar expansions', () => {
+    expect(only(run('echo hello'), 'PS023')).toEqual([]);
+    expect(only(run('vite build'), 'PS023')).toEqual([]);
+  });
+
+  it('negative: $env: belongs to PS003', () => {
+    expect(only(run("$env:X='1'; node a"), 'PS023')).toEqual([]);
+  });
+
+  it('medium confidence, warn severity', () => {
+    const [f] = only(run('echo $HOME'), 'PS023');
+    expect(f?.confidence).toBe('medium');
+    expect(f?.severity).toBe('warn');
+  });
+});
+
+describe('PS024 CMD_VAR_EXPANSION', () => {
+  it('positive: %VAR% forms', () => {
+    expect(only(run('echo %APPDATA%'), 'PS024')).toHaveLength(1);
+    expect(only(run('mkdir "%USERPROFILE%\\build"'), 'PS024')).toHaveLength(1);
+    expect(only(run('node x --p %npm_package_version%'), 'PS024')).toHaveLength(1);
+  });
+
+  it('negative: format strings without closing percent', () => {
+    expect(only(run("printf '%s\\n' hello"), 'PS024')).toEqual([]);
+    expect(only(run('date +%Y-%m-%d'), 'PS024')).toEqual([]);
+    expect(only(run('echo 100%'), 'PS024')).toEqual([]);
+  });
+});
+
+describe('PS025 DEV_NULL', () => {
+  it('positive: /dev/null in args and redirects', () => {
+    expect(only(run('node heavy.js > /dev/null'), 'PS025')).toHaveLength(1);
+    expect(only(run('cmd 2> /dev/null'), 'PS025')).toHaveLength(1);
+    expect(only(run('cat /dev/null'), 'PS025')).toHaveLength(1);
+  });
+
+  it('negative: regular files', () => {
+    expect(only(run('node heavy.js > out.log'), 'PS025')).toEqual([]);
+    expect(only(run('echo /dev'), 'PS025')).toEqual([]);
+    expect(only(run('vite build'), 'PS025')).toEqual([]);
+  });
+});
+
+describe('PS026 UNIX_PATH_ASSUMPTION', () => {
+  it('positive: hardcoded unix paths', () => {
+    expect(only(run('cp x /tmp/'), 'PS026')).toHaveLength(1);
+    expect(only(run('mkdir /usr/local/etc/app'), 'PS026')).toHaveLength(1);
+    expect(only(run('ls /var/log'), 'PS026')).toHaveLength(1);
+  });
+
+  it('negative: relative paths and urls', () => {
+    expect(only(run('cp x ./tmp/'), 'PS026')).toEqual([]);
+    expect(only(run('curl http://x/api/y'), 'PS026')).toEqual([]);
+    expect(only(run('node app.js'), 'PS026')).toEqual([]);
+  });
+
+  it('advisory severity', () => {
+    const [f] = only(run('ls /tmp'), 'PS026');
+    expect(f?.severity).toBe('advisory');
+  });
+});


### PR DESCRIPTION
## Summary
Adds 17 rules: POSIX command availability (rm, cp, mv, mkdir -p, touch, chmod, which, grep, sed, cat), command substitution / export / source, variable-expansion mismatches ($VAR vs %VAR%), /dev/null, and Unix path assumptions. Expansion checks cover redirect targets as well as argv. The registry now holds 23 of the 26 v0.1 rules.

## Why
Milestone M2 part 2 (spec §6): the scripts-doctor parity set — one explainable rule per command rather than one big rewrite, with per-rule target shells, confidence, and provenance.

## Rule semantics changed?
New rules only.

## Test evidence
Every rule ships ≥3 positive + ≥3 negative fixtures (quoted strings, shx/rimraf command positions, wrapper payloads never re-reported). CI must be green on all three OSes.

## Risk and rollback
New rule modules behind the registry. Revert the single commit if a rule misbehaves.

## Checklist
- [x] Tests added (17 rules × 6+ cases)
- [x] No new runtime dependency
- [x] No execution of analyzed scripts; no telemetry
- [x] Third-party actions pinned