### PR TITLE
feat(action): M6 — first-class GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,46 @@
+name: 'scriptspect'
+description: >-
+  Cross-platform static analysis for package.json scripts — catches
+  shell-specific commands before they break Windows, macOS, or Linux builds.
+author: 'Tom409114'
+
+branding:
+  icon: 'search'
+  color: 'blue'
+
+inputs:
+  path:
+    description: 'Project path to analyze (defaults to the repository root).'
+    required: false
+    default: '.'
+  target:
+    description: 'Target shells, comma-separated: posix-sh, cmd, powershell.'
+    required: false
+    default: 'posix-sh,cmd'
+  severity:
+    description: 'Minimum severity to display: error, warn, or advisory.'
+    required: false
+    default: 'advisory'
+  max-warnings:
+    description: 'Fail the job when warnings exceed this number (omit for unlimited).'
+    required: false
+    default: ''
+  version:
+    description: 'scriptspect npm version or dist-tag to run (e.g. latest, 0.1.0).'
+    required: false
+    default: 'latest'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Run scriptspect
+      shell: bash
+      run: |
+        # Spec §12.1: the Action uses the same CLI core — one rule engine,
+        # never a fork. It never modifies the repository (fix mode is not
+        # offered in CI).
+        ARGS=(check "${{ inputs.path }}" --format github --target "${{ inputs.target }}" --severity "${{ inputs.severity }}")
+        if [ -n "${{ inputs.max-warnings }}" ]; then
+          ARGS+=(--max-warnings "${{ inputs.max-warnings }}")
+        fi
+        npx --yes "scriptspect@${{ inputs.version }}" "${ARGS[@]}"

--- a/tests/integration/action.test.ts
+++ b/tests/integration/action.test.ts
@@ -1,0 +1,39 @@
+/**
+ * action.yml contract tests (spec §12): the Action is a thin wrapper over
+ * the same CLI core; inputs map 1:1 to flags; it never commits fixes.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const action = readFileSync(join(root, 'action.yml'), 'utf8');
+
+describe('GitHub Action contract (spec §12.1)', () => {
+  it('is a composite action using the CLI (same core, no forked logic)', () => {
+    expect(action).toContain("using: 'composite'");
+    expect(action).toContain('npx --yes "scriptspect@');
+    expect(action).toContain('--format github');
+  });
+
+  it('exposes the spec input set: target and severity', () => {
+    expect(action).toContain('target:');
+    expect(action).toContain('severity:');
+  });
+
+  it('defaults mirror the CLI defaults (posix-sh + cmd, advisory)', () => {
+    expect(action).toContain("default: 'posix-sh,cmd'");
+    expect(action).toContain("default: 'advisory'");
+  });
+
+  it('supports explicit paths and warning budgets', () => {
+    expect(action).toContain('path:');
+    expect(action).toContain('max-warnings:');
+  });
+
+  it('never modifies the repository (no fix mode in CI)', () => {
+    expect(action).not.toContain('--fix');
+    expect(action).not.toContain('git ');
+  });
+});

--- a/tests/integration/action.test.ts
+++ b/tests/integration/action.test.ts
@@ -2,10 +2,11 @@
  * action.yml contract tests (spec §12): the Action is a thin wrapper over
  * the same CLI core; inputs map 1:1 to flags; it never commits fixes.
  */
-import { describe, expect, it } from 'vitest';
+
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const action = readFileSync(join(root, 'action.yml'), 'utf8');


### PR DESCRIPTION
## Summary
Adds action.yml (composite) that runs the CLI via npx with github-annotation formatting. Inputs: path, target, severity, max-warnings, version. Defaults mirror the CLI (posix-sh,cmd / advisory). The action never offers --fix and never mutates the repo.

## Why
Milestone M6 (spec §12): turn 'someone tried it' into 'someone depends on it' via a one-line uses: integration.

## Rule semantics changed?
No change (integration wrapper only).

## Test evidence
Contract tests assert the input set, defaults, same-core invocation, and no-repo-mutation invariant. CI on all three OSes.

## Risk and rollback
New action.yml + tests only. Revert the commit to remove.

## Checklist
- [x] Same CLI core (no forked rules)
- [x] Never modifies the repo in CI
- [x] Third-party actions pinned