### PR TITLE
feat(corpus): M8 — read-only corpus scanner + validation methodology

### DIFF
--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -1,0 +1,49 @@
+name: Corpus scan (read-only)
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo-count:
+        description: 'How many popular JS/TS repos to sample from GitHub search'
+        required: false
+        default: '100'
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 22
+          package-manager-cache: false
+      - run: npm install -g pnpm@11.24.0
+      - run: pnpm install --no-frozen-lockfile
+      - name: Build the repo sample (public search API, read-only)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "search/repositories?q=language:typescript+stars:%3E2000&sort=stars&order=desc&per_page=${{ inputs.repo-count }}" \
+            --jq '.items[].full_name' > repos.txt || true
+          # JavaScript repos broaden the sample beyond the TypeScript search
+          gh api "search/repositories?q=language:javascript+stars:%3E5000&sort=stars&order=desc&per_page=50" \
+            --jq '.items[].full_name' >> repos.txt || true
+          sort -u repos.txt -o repos.txt
+          wc -l repos.txt
+      - name: Scan scripts (never writes to any scanned repo)
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: pnpm exec tsx tools/corpus-scan.ts repos.txt
+      - name: Upload draft outputs for human precision sampling
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: corpus-draft
+          path: |
+            repos.txt
+            findings.jsonl
+            summary.md
+          retention-days: 30

--- a/docs/evidence/corpus-method.md
+++ b/docs/evidence/corpus-method.md
@@ -1,0 +1,39 @@
+# Corpus validation methodology (M8)
+
+How scriptspect validates precision against real public code — reproducible and
+free of hand-entered numbers (spec §16, §20).
+
+## Scan
+
+1. `corpus.yml` (manual dispatch) samples popular public JS/TS repositories
+   via the GitHub search API and records the list in `repos.txt`.
+2. `tools/corpus-scan.ts` fetches each repo's `package.json` read-only and
+   runs the full rule engine over its scripts with default targets
+   (`posix-sh`, `cmd`).
+3. Outputs (uploaded as the `corpus-draft` artifact, never auto-committed):
+   - `findings.jsonl` — one line per finding (repo, script, rule, message,
+     source) for traceable verification
+   - `summary.md` — counts per rule/repo
+
+## Precision sampling (human gate)
+
+- Sample findings uniformly (≥100) and verify each against the repo's real
+  scripts: would this command actually fail on a default Windows npm setup?
+- Precision = verified / sampled, reported overall and per rule.
+- Every false positive becomes a regression fixture in `tests/rules/` before
+  the rule is adjusted (spec §11.2 golden corpus).
+
+## Publication rules
+
+- Only human-verified numbers may appear in `docs/evidence/`.
+- Draft outputs stay as CI artifacts; unverified data is never committed.
+- Scanning is strictly read-only: no issues, PRs, or comments on third-party
+  repositories without explicit authorization (spec §0 COMMUNITY-02).
+
+## Kill-or-commit thresholds (spec §16)
+
+| Gate | Continue if | Otherwise |
+| --- | --- | --- |
+| Overall precision | ≥85% sampled (P0 high-confidence rules ≥95%) | <80%: stop adding rules, fix parser/context |
+| Real-problem density | ≥20 confirmed issues in ≥10 projects, ≥4 rule classes | re-evaluate scope |
+| Competitive edge | finds real issues scripts-doctor misses, without more FPs | don't publish; improve |

--- a/tools/corpus-scan.ts
+++ b/tools/corpus-scan.ts
@@ -11,11 +11,10 @@
  * The scanner never writes to third-party repositories (spec §0 COMMUNITY-02)
  * and never executes analyzed scripts (QUALITY-02).
  */
-import { createWriteStream } from 'node:fs';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { createWriteStream, readFileSync, writeFileSync } from 'node:fs';
+import { DEFAULT_TARGETS } from '../src/core/targets';
 import { analyzeScript } from '../src/rules';
 import type { Finding } from '../src/rules/types';
-import { DEFAULT_TARGETS } from '../src/core/targets';
 
 interface RepoManifest {
   name?: string;
@@ -79,7 +78,9 @@ async function main(): Promise<void> {
     console.error('usage: tsx tools/corpus-scan.ts repos.txt');
     process.exit(2);
   }
-  const repos = readFileSync(listFile, 'utf8').split(String.fromCharCode(10)).map((l) => l.trim());
+  const repos = readFileSync(listFile, 'utf8')
+    .split(String.fromCharCode(10))
+    .map((l) => l.trim());
   const findingsOut = createWriteStream('findings.jsonl', 'utf8');
   const reposWithScripts: string[] = [];
   const scriptsScannedTotal: number[] = [];
@@ -148,10 +149,15 @@ async function main(): Promise<void> {
     '',
     '| Repo | Findings |',
     '| --- | --- |',
-    ...[...byRepo.entries()].sort((a, b) => b[1] - a[1]).slice(0, 20).map(([r, c]) => `| ${r} | ${c} |`),
+    ...[...byRepo.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 20)
+      .map(([r, c]) => `| ${r} | ${c} |`),
   ];
   writeFileSync('summary.md', lines.join('\n'), 'utf8');
-  console.log(`scanned ${reposWithScripts.length} repos, ${scriptsScanned} scripts, ${findingCount} findings`);
+  console.log(
+    `scanned ${reposWithScripts.length} repos, ${scriptsScanned} scripts, ${findingCount} findings`,
+  );
 }
 
 await main();

--- a/tools/corpus-scan.ts
+++ b/tools/corpus-scan.ts
@@ -1,0 +1,157 @@
+/**
+ * Public-corpus scanner (spec §16 Day 8-9, M8-01): read-only.
+ *
+ * Reads a list of `owner/repo` lines, fetches each repo's package.json via
+ * the GitHub API, runs the full rule engine over its scripts, and writes:
+ *  - findings.jsonl  (one line per finding: repo, script, rule, message)
+ *  - summary.md      (per-rule counts + coverage stats — a DATA DRAFT for
+ *                     human precision sampling, never auto-committed as
+ *                     evidence per docs/evidence policy)
+ *
+ * The scanner never writes to third-party repositories (spec §0 COMMUNITY-02)
+ * and never executes analyzed scripts (QUALITY-02).
+ */
+import { createWriteStream } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { analyzeScript } from '../src/rules';
+import type { Finding } from '../src/rules/types';
+import { DEFAULT_TARGETS } from '../src/core/targets';
+
+interface RepoManifest {
+  name?: string;
+  scripts?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  bin?: string | Record<string, string>;
+}
+
+const GITHUB_API = 'https://api.github.com';
+
+async function fetchManifest(repo: string, token: string): Promise<RepoManifest | null> {
+  const res = await fetch(`${GITHUB_API}/repos/${repo}/contents/package.json`, {
+    headers: {
+      Accept: 'application/vnd.github.raw+json',
+      Authorization: `Bearer ${token}`,
+      'User-Agent': 'scriptspect-corpus-scan',
+    },
+  });
+  if (!res.ok) return null;
+  try {
+    return (await res.json()) as RepoManifest;
+  } catch {
+    return null;
+  }
+}
+
+function dependencyNames(manifest: RepoManifest): Set<string> {
+  const names = new Set<string>();
+  for (const block of [
+    manifest.dependencies,
+    manifest.devDependencies,
+    manifest.optionalDependencies,
+    manifest.peerDependencies,
+  ]) {
+    if (block === undefined) continue;
+    for (const name of Object.keys(block)) names.add(name);
+  }
+  return names;
+}
+
+function ownBins(manifest: RepoManifest): Set<string> {
+  const names = new Set<string>();
+  if (manifest.name !== undefined) names.add(manifest.name);
+  if (typeof manifest.bin === 'object' && manifest.bin !== null) {
+    for (const bin of Object.keys(manifest.bin)) names.add(bin);
+  }
+  return names;
+}
+
+async function main(): Promise<void> {
+  const token = process.env.GITHUB_TOKEN ?? '';
+  if (token === '') {
+    console.error('GITHUB_TOKEN is required (read-only public access)');
+    process.exit(2);
+  }
+  const listFile = process.argv[2];
+  if (listFile === undefined) {
+    console.error('usage: tsx tools/corpus-scan.ts repos.txt');
+    process.exit(2);
+  }
+  const repos = readFileSync(listFile, 'utf8').split(String.fromCharCode(10)).map((l) => l.trim());
+  const findingsOut = createWriteStream('findings.jsonl', 'utf8');
+  const reposWithScripts: string[] = [];
+  const scriptsScannedTotal: number[] = [];
+  const byRule = new Map<string, number>();
+  const byRepo = new Map<string, number>();
+  let findingCount = 0;
+
+  for (const repo of repos) {
+    if (repo === '' || repo.startsWith('#')) continue;
+    const manifest = await fetchManifest(repo, token);
+    if (manifest === null || manifest.scripts === undefined) continue;
+    const scripts = Object.entries(manifest.scripts).filter(([, v]) => typeof v === 'string');
+    if (scripts.length === 0) continue;
+    reposWithScripts.push(repo);
+    const dependencies = dependencyNames(manifest);
+    const workspaceBins = ownBins(manifest);
+    scriptsScannedTotal.push(scripts.length);
+
+    for (const [scriptName, script] of scripts as Array<[string, string]>) {
+      const findings: Finding[] = analyzeScript(script, {
+        script,
+        scriptName,
+        packagePath: 'package.json',
+        targets: DEFAULT_TARGETS,
+        dependencies,
+        workspaceBins,
+      });
+      for (const f of findings) {
+        findingCount += 1;
+        byRule.set(f.ruleId, (byRule.get(f.ruleId) ?? 0) + 1);
+        byRepo.set(repo, (byRepo.get(repo) ?? 0) + 1);
+        findingsOut.write(
+          JSON.stringify({
+            repo,
+            script: scriptName,
+            ruleId: f.ruleId,
+            severity: f.severity,
+            confidence: f.confidence,
+            affectedTargets: f.affectedTargets,
+            message: f.message,
+            source: script,
+          }) + '\n',
+        );
+      }
+    }
+    await new Promise((r) => setTimeout(r, 250)); // stay well inside rate limits
+  }
+
+  findingsOut.end();
+  const scriptsScanned = scriptsScannedTotal.reduce((a, b) => a + b, 0);
+  const lines = [
+    '# Corpus scan draft (unverified — for human precision sampling only)',
+    '',
+    `- Repos scanned with scripts: ${reposWithScripts.length}`,
+    `- Scripts analyzed: ${scriptsScanned}`,
+    `- Findings: ${findingCount}`,
+    `- Distinct rules triggered: ${byRule.size}`,
+    '',
+    '## Findings by rule',
+    '',
+    '| Rule | Findings |',
+    '| --- | --- |',
+    ...[...byRule.entries()].sort((a, b) => b[1] - a[1]).map(([r, c]) => `| ${r} | ${c} |`),
+    '',
+    '## Top repos by finding count',
+    '',
+    '| Repo | Findings |',
+    '| --- | --- |',
+    ...[...byRepo.entries()].sort((a, b) => b[1] - a[1]).slice(0, 20).map(([r, c]) => `| ${r} | ${c} |`),
+  ];
+  writeFileSync('summary.md', lines.join('\n'), 'utf8');
+  console.log(`scanned ${reposWithScripts.length} repos, ${scriptsScanned} scripts, ${findingCount} findings`);
+}
+
+await main();


### PR DESCRIPTION
## Summary
Adds the read-only corpus scanner (GitHub API fetch + full rule engine), a manual-dispatch workflow that samples popular JS/TS repos and uploads draft artifacts, and the precision-sampling methodology doc with kill-or-commit thresholds.

## Why
Milestone M8 (spec §16): validate precision against real public code before expanding rules.

## Rule semantics changed?
No change (validation tooling only).

## Test evidence
Scanner is a workflow_dispatch tool; the workflow and methodology doc are linted. CI on all three OSes (the tool itself is not in the typecheck graph but is exercised by the workflow).

## Risk and rollback
New tool + workflow + doc only. Revert the commit to remove.

## Checklist
- [x] Strictly read-only (no writes to third-party repos)
- [x] Draft data never auto-committed as evidence
- [x] Third-party actions pinned