### PR TITLE
feat(release): M7 — SHA-256 checksums, release assets, published-tarball verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,3 +43,73 @@ jobs:
       - run: pnpm build
       - name: Publish with provenance (requires npm trusted publishing configuration)
         run: npm publish --provenance --access public
+
+  # M7 (spec §13.1 / §23): the GitHub Release carries a reproducible
+  # tarball plus a SHA-256 checksum manifest, and the bytes npm published are
+  # verified byte-for-byte (by content) against the tarball built in CI.
+  checksums:
+    name: Release checksums and assets (SHA-256)
+    needs: [release-please, publish-npm]
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - run: npm install -g pnpm@11.24.0
+      - run: pnpm install --no-frozen-lockfile
+      - run: pnpm build
+      - name: Pack the release tarball
+        id: pack
+        run: |
+          TARBALL=$(pnpm pack --pack-destination "$RUNNER_TEMP" | tail -1)
+          echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
+          echo "Packed $TARBALL"
+      - name: Smoke-test the packed artifact
+        run: |
+          mkdir -p "$RUNNER_TEMP/verify"
+          tar -xzf "$RUNNER_TEMP/${{ steps.pack.outputs.tarball }}" -C "$RUNNER_TEMP/verify"
+          node "$RUNNER_TEMP/verify/package/dist/cli.mjs" --version
+          node "$RUNNER_TEMP/verify/package/dist/cli.mjs" --help >/dev/null
+      - name: Generate SHA256SUMS
+        run: |
+          cd "$RUNNER_TEMP"
+          sha256sum "${{ steps.pack.outputs.tarball }}" | tee SHA256SUMS
+      - name: Verify the published npm tarball matches the local pack
+        run: |
+          cd "$RUNNER_TEMP"
+          VERSION="${{ needs.release-please.outputs.tag_name }}"
+          VERSION="${VERSION#v}"
+          curl -fsSL -o published.tgz \
+            "https://registry.npmjs.org/scriptspect/-/scriptspect-${VERSION}.tgz"
+          mkdir -p local npm
+          tar -xzf "${{ steps.pack.outputs.tarball }}" -C local
+          tar -xzf published.tgz -C npm
+          # File-set parity (no missing/extra files between CI pack and npm).
+          ( cd local/package && find . -type f | sort ) > local-files.txt
+          ( cd npm/package && find . -type f | sort ) > npm-files.txt
+          if ! diff -u local-files.txt npm-files.txt; then
+            echo "::error::published npm tarball file set differs from the CI-built tarball" >&2
+            exit 1
+          fi
+          # Content digest of the shipped runtime artifact (dist/).
+          digest() { ( cd "$1" && find . -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum | cut -d' ' -f1 ); }
+          LOCAL=$(digest local/package/dist)
+          NPM=$(digest npm/package/dist)
+          echo "local  dist sha256: $LOCAL"
+          echo "npm    dist sha256: $NPM"
+          test "$LOCAL" = "$NPM" || { echo "::error::published dist/ content differs from CI build" >&2; exit 1; }
+      - name: Upload tarball and checksums to the release
+        run: |
+          gh release upload "${{ needs.release-please.outputs.tag_name }}" \
+            "$RUNNER_TEMP/${{ steps.pack.outputs.tarball }}" \
+            "$RUNNER_TEMP/SHA256SUMS" --clobber
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## M7: Release hardening (spec §11, §13.1, §23)

- **Checksums**: new `checksums` job packs the release tarball from the tagged commit and writes `SHA256SUMS` (SHA-256 of the tarball)
- **Release assets**: uploads the tarball + `SHA256SUMS` to the GitHub Release via `gh release upload`
- **Integrity verification**: downloads the just-published npm tarball and verifies its file set and `dist/` content digest match the CI-built pack — *tag → npm* fully verifiable, no local token
- **Smoke test**: the packed artifact's CLI runs `--version` and `--help` before shipping
- Trusted npm publish with provenance (`npm publish --provenance`) unchanged

Fixes #41 (M7-01)