### PR TITLE
fix(ci): release-please first release is v0.1.0, not 1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
         id: release
         with:
           release-type: node
+          # First release is v0.1.0 (docs/roadmap, README support matrix), not
+          # release-please's 1.0.0 default for an untagged 0.0.0 baseline.
+          initial-version: 0.1.0
 
   publish-npm:
     name: Publish to npm (trusted publishing)


### PR DESCRIPTION
## Problem

release-please proposed the first release as **v1.0.0** (PR #56) because the repo is untagged at version `0.0.0` and it defaults to a major for the initial release. The project's documented release plan is **v0.1** — README support matrix ("v0.1 status"), docs/roadmap (M7 "v0.1.0 first publish"), and README's `Tom409114/scriptspect@v0.1` action reference.

## Change

Add `initial-version: 0.1.0` to the release-please step in `.github/workflows/release.yml`.

## Effect

On the next push to main, release-please will regenerate the release PR (#56) to propose **v0.1.0** instead of v1.0.0.

## Testing

- CI runs on this PR (workflow syntax + release-please action config lint).
- The `Release` workflow is not triggered by PR branches, only by `push` to `main` — verified release-please runs green after the permission fix (run #33397279240).
