### PR TITLE
fix(action): honor scriptspect.config.json when target/severity inputs are unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,14 @@ Rules: [docs/rules](docs/rules) — each with why/bad/good examples, false-posit
 
 ## Use it in CI
 
-The GitHub Action runs the same CLI core, emits inline annotations plus a job summary, and fails the job on findings:
+The GitHub Action runs the same CLI core, emits inline annotations plus a job summary, and fails the job on high-confidence errors (or when the warning budget is exceeded):
 
 ```yaml
 - uses: Tom409114/scriptspect@v0.1
   with:
     path: .            # project path to analyze (default: repository root)
-    target: posix-sh,cmd
+    # target / severity are optional. Omit them (as here) to honor the
+    # project's scriptspect.config.json; set them to override it.
 ```
 
 Or call the CLI directly:

--- a/action.yml
+++ b/action.yml
@@ -14,13 +14,17 @@ inputs:
     required: false
     default: '.'
   target:
-    description: 'Target shells, comma-separated: posix-sh, cmd, powershell.'
+    description: >-
+      Target shells, comma-separated: posix-sh, cmd, powershell. Omit to honor
+      the project's scriptspect.config.json (CLI default: posix-sh,cmd).
     required: false
-    default: 'posix-sh,cmd'
+    default: ''
   severity:
-    description: 'Minimum severity to display: error, warn, or advisory.'
+    description: >-
+      Minimum severity to display: error, warn, or advisory. Omit to honor the
+      project's scriptspect.config.json (CLI default: advisory).
     required: false
-    default: 'advisory'
+    default: ''
   max-warnings:
     description: 'Fail the job when warnings exceed this number (omit for unlimited).'
     required: false
@@ -38,8 +42,15 @@ runs:
       run: |
         # Spec §12.1: the Action uses the same CLI core — one rule engine,
         # never a fork. It never modifies the repository (fix mode is not
-        # offered in CI).
-        ARGS=(check "${{ inputs.path }}" --format github --target "${{ inputs.target }}" --severity "${{ inputs.severity }}")
+        # offered in CI). When target/severity are not set the flags are
+        # omitted so the CLI honors scriptspect.config.json settings.
+        ARGS=(check "${{ inputs.path }}" --format github)
+        if [ -n "${{ inputs.target }}" ]; then
+          ARGS+=(--target "${{ inputs.target }}")
+        fi
+        if [ -n "${{ inputs.severity }}" ]; then
+          ARGS+=(--severity "${{ inputs.severity }}")
+        fi
         if [ -n "${{ inputs.max-warnings }}" ]; then
           ARGS+=(--max-warnings "${{ inputs.max-warnings }}")
         fi

--- a/tests/integration/action.test.ts
+++ b/tests/integration/action.test.ts
@@ -23,9 +23,17 @@ describe('GitHub Action contract (spec §12.1)', () => {
     expect(action).toContain('severity:');
   });
 
-  it('defaults mirror the CLI defaults (posix-sh + cmd, advisory)', () => {
-    expect(action).toContain("default: 'posix-sh,cmd'");
-    expect(action).toContain("default: 'advisory'");
+  it('omits --target/--severity when unset so config-file settings are honored', () => {
+    // With empty defaults, the CLI falls back to scriptspect.config.json
+    // (then its own defaults). Flags are appended only when set explicitly.
+    expect(action).toContain("default: ''");
+    expect(action).toContain('if [ -n "${{ inputs.target }}" ]; then');
+    expect(action).toContain('if [ -n "${{ inputs.severity }}" ]; then');
+  });
+
+  it('still supports explicit target/severity overrides', () => {
+    expect(action).toContain('--target "${{ inputs.target }}"');
+    expect(action).toContain('--severity "${{ inputs.severity }}"');
   });
 
   it('supports explicit paths and warning budgets', () => {


### PR DESCRIPTION
## What changed

The composite Action unconditionally passed `--target` and `--severity`, silently overriding project-level `scriptspect.config.json` settings. Now `target`/`severity` default to `''` and the flags are appended only when set explicitly — matching the CLI's own config-file-first resolution.

- **action.yml**: `target`/`severity` → empty defaults; conditional flag appending
- **tests/integration/action.test.ts**: contract tests assert the omit-when-unset behavior and the explicit-override path
- **README.md**: corrects the "fails the job on findings" overstatement; marks `target`/`severity` optional in the Action example

## Why

Found by the release-readiness adversarial review (spec §23 DoD — review confirms findings): a user with `"severity": { ... }` or `"targets": [...]` in `scriptspect.config.json` gets those settings clobbered by the Action's hard-coded defaults.

## Risk / semantics change

- **Semantic change**: PRs using the Action without `target`/`severity` inputs will now honor config-file overrides instead of clobbering them. Explicit inputs still win. This is the intended, documented behavior of the CLI flags.
- **Tests**: existing action contract tests updated; CI covers lint/typecheck/unit/integration/cross-platform.
- No dependency or supply-chain changes.

## DoD checklist

- [x] CI green (lint / typecheck / unit / integration)
- [x] Positive + negative behavior covered by contract tests
- [x] Docs updated (README)
- [x] Semantic change called out