### PR TITLE
fix: keep release changelog sections unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,3 @@
 # Changelog
 
-## 0.1.0 (Unreleased)
-
-
-### Features
-
-* **action:** M6 — first-class GitHub Action ([#51](https://github.com/Tom409114/scriptspect/issues/51)) ([24a5bf8](https://github.com/Tom409114/scriptspect/commit/24a5bf8ebcae7ead125dc4d50ddfd0e95d53fa9f))
-* **corpus:** M8 — read-only corpus scanner + validation methodology ([#52](https://github.com/Tom409114/scriptspect/issues/52)) ([3285d58](https://github.com/Tom409114/scriptspect/commit/3285d58415ebfea0d2acb9ce85af283eeb3bc961))
-* **fixer:** M4 — safe fixes with dry-run and idempotency ([#49](https://github.com/Tom409114/scriptspect/issues/49)) ([a91723b](https://github.com/Tom409114/scriptspect/commit/a91723b5c24a0ba514c06755fb7bf08c78b1e2ea))
-* **parser:** quote/escape/operator-aware lexer + command IR (M1) ([#44](https://github.com/Tom409114/scriptspect/issues/44)) ([4292fe3](https://github.com/Tom409114/scriptspect/commit/4292fe3f16ada6291f223f1a6be8a1ac7174587f))
-* **release:** M7 — SHA-256 checksums, release assets, published-tarball verification ([#53](https://github.com/Tom409114/scriptspect/issues/53)) ([2b339db](https://github.com/Tom409114/scriptspect/commit/2b339dbeba6086fe3e4229f396afbf737badc75e))
-* **reporter,cli,config:** M3 — one command to actionable findings ([#48](https://github.com/Tom409114/scriptspect/issues/48)) ([ece45da](https://github.com/Tom409114/scriptspect/commit/ece45da3c3b70235ba43f498f4dbc64f1660cc91))
-* **rules:** POSIX command + syntax rules PS010-PS026 (M2 part 2) ([#46](https://github.com/Tom409114/scriptspect/issues/46)) ([125fdaa](https://github.com/Tom409114/scriptspect/commit/125fdaa578b947764684e31d5a8fd9474a9117e8))
-* **rules:** PS040, PS041, PS050 — v0.1 rule set complete (M2 part 3) ([#47](https://github.com/Tom409114/scriptspect/issues/47)) ([8e23d25](https://github.com/Tom409114/scriptspect/commit/8e23d25eaf2ac20a889685e315004de3f1416049))
-* **rules:** rule engine + PS001-PS003, PS030-PS032 (M2 part 1) ([#45](https://github.com/Tom409114/scriptspect/issues/45)) ([5b877da](https://github.com/Tom409114/scriptspect/commit/5b877da4445c62bedc97de04b6451ddcad108e59))
-* **workspaces:** M5 — monorepo discovery + workspace-bin-aware PS040 ([#50](https://github.com/Tom409114/scriptspect/issues/50)) ([cc67eee](https://github.com/Tom409114/scriptspect/commit/cc67eee39bee126cc1c5228211b88ca80e7ce33e))
-
-
-### Bug Fixes
-
-* **ci:** configure release-please via config file for initial-version 0.1.0 ([#59](https://github.com/Tom409114/scriptspect/issues/59)) ([33fc062](https://github.com/Tom409114/scriptspect/commit/33fc062d74c4c5cd6864668bbb86fe476a4321f5))
-* **ci:** job-level hashFiles broke workflow validation ([#5](https://github.com/Tom409114/scriptspect/issues/5)) ([25839b4](https://github.com/Tom409114/scriptspect/commit/25839b493c9cd08b0d196b30c14387b723d62e08))
-* **ci:** release-please first release is v0.1.0, not 1.0.0 ([#57](https://github.com/Tom409114/scriptspect/issues/57)) ([20a9b12](https://github.com/Tom409114/scriptspect/commit/20a9b123f6a950d42f299bc89d32953001221ce7))
+## Unreleased

--- a/tests/docs/public-claims.test.ts
+++ b/tests/docs/public-claims.test.ts
@@ -40,6 +40,7 @@ describe('public project claims', () => {
 
     expect(security).toContain('No npm release has been published yet');
     expect(maintainers).toContain('After the first release');
-    expect(changelog).toContain('## 0.1.0 (Unreleased)');
+    expect(changelog).toContain('## Unreleased');
+    expect(changelog).not.toMatch(/^## 0\.1\.0 \(Unreleased\)$/mu);
   });
 });

--- a/tests/integration/package-contents.test.ts
+++ b/tests/integration/package-contents.test.ts
@@ -36,5 +36,5 @@ describe('published package contents', () => {
     expect(paths).toContain('schema/output.schema.json');
     expect(paths).toContain('README.md');
     expect(paths).toContain('README.zh-CN.md');
-  }, 20_000);
+  }, 60_000);
 });


### PR DESCRIPTION
## Summary\n\n- keep the changelog baseline under a generic Unreleased heading\n- let release-please own the first dated 