### PR TITLE
fix: keep first release changelog canonical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,0 @@
-# Changelog
-
-## Unreleased

--- a/tests/docs/public-claims.test.ts
+++ b/tests/docs/public-claims.test.ts
@@ -37,10 +37,19 @@ describe('public project claims', () => {
     const security = read('SECURITY.md');
     const maintainers = read('MAINTAINERS.md');
     const changelog = read('CHANGELOG.md');
+    const releaseManifest = JSON.parse(read('.release-please-manifest.json')) as Record<
+      string,
+      string
+    >;
 
     expect(security).toContain('No npm release has been published yet');
     expect(maintainers).toContain('After the first release');
-    expect(changelog).toContain('## Unreleased');
-    expect(changelog).not.toMatch(/^## 0\.1\.0 \(Unreleased\)$/mu);
+    if (releaseManifest['.'] === '0.0.0') {
+      expect(changelog).toBe('');
+    } else {
+      expect(changelog).toMatch(/^# Changelog$/mu);
+    }
+    expect(changelog).not.toMatch(/^## \d+\.\d+\.\d+ \(Unreleased\)$/mu);
+    expect(changelog).not.toMatch(/^## Changelog$/mu);
   });
 });


### PR DESCRIPTION
## Summary\n\n- keep the pre-first-release changelog empty so release-please creates the single canonical # Changelog header\n- prevent release-please from demoting an existing header into a stray ## Changelog section\n- preserve regression checks against versioned Unreleased headings and nested changelog headers\n\n## Why\n\nThe current release-please updater only recognizes version headings containing a digit. With non-version content in the pre-release file, its first-release path prepends a new header and demotes the existing header, which produced an extra ## Changelog in PR #66.\n\n## Verification\n\n- pnpm test — 55 files, 600 passed, 6 skipped\n- pnpm typecheck\n- pnpm lint\n- pnpm audit --audit-level=low — no known vulnerabilities\n- pnpm install --frozen-lockfile\n- git diff --check\n\nThis PR only corrects release metadata generation. It does not publish npm, create tags, or create a GitHub Release.