### PR TITLE
docs: refresh final remote validation evidence

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,16 +4,23 @@ The links below record when each implementation slice first landed. A merged
 slice is not the same as satisfying its exit condition: release, hosted-CI,
 corpus, and adoption gates stay open until their public evidence exists.
 
+Remote engineering evidence includes the merged [hardening PR #65](https://github.com/Tom409114/scriptspect/pull/65),
+[main CI run `33447746364`](https://github.com/Tom409114/scriptspect/actions/runs/33447746364),
+and the still-open [v0.1.0 release PR #66](https://github.com/Tom409114/scriptspect/pull/66)
+with [16/16 required jobs green](https://github.com/Tom409114/scriptspect/actions/runs/33447786827).
+The [DoD ledger](validation/v0.1-dod-2026-09-01.md) records the remaining
+publication, tag-actor, and external-evidence gates.
+
 | Milestone | Theme | Key deliverables | Exit condition | Status |
 | --- | --- | --- | --- | --- |
-| M0 | Remote repo and competitive baseline | GitHub repo, license, CI skeleton, issue/PR templates, scripts-doctor parity checklist, name-availability gate | `main` is buildable by hosted Actions and repository controls are recorded | implementation merged; hosted controls pending |
-| M1 | Parser / IR | target-aware lexer, parse matrix, exact spans, negative fixtures | parser matrix and scoped coverage gates pass on all supported OS/Node combinations | hardening in progress |
-| M2 | P0 portability rules | PS001/010/011/012/013/020/021/022/030/040 + the full v0.1 rule set | deterministic positive/negative fixtures and reviewed precision evidence | implementation merged; final matrix pending |
-| M3 | Reporter + explain | stylish/json/github reporters; rule docs; `explain` command | one command yields actionable findings; published JSON schemas are frozen | implementation merged; publication pending |
-| M4 | Safe fixer | fix safety model, dry-run, cross-env/rimraf/shx conditional fixes | idempotency, concurrency, rollback, and recovery tests pass | hardening in progress |
-| M5 | Workspaces | npm/pnpm/Yarn/Bun discovery; PS040 workspace-bin awareness | real manager fixtures and a hosted 100-package benchmark under 2 seconds | implementation merged; hosted benchmark pending |
-| M6 | GitHub Action | bundled Node Action + annotations + job summary; 3-OS matrix | immutable released reference runs in an external repository | implementation in progress; release evidence pending |
-| M7 | Release | npm trusted publishing, provenance, release notes, checksums | one immutable tarball reaches npm and GitHub Release through Actions | workflow hardening in progress; first release pending |
+| M0 | Remote repo and competitive baseline | GitHub repo, license, CI skeleton, issue/PR templates, scripts-doctor parity checklist, name-availability gate | `main` is buildable by hosted Actions and repository controls are recorded | implementation, hosted CI, and main controls verified |
+| M1 | Parser / IR | target-aware lexer, parse matrix, exact spans, negative fixtures | parser matrix and scoped coverage gates pass on all supported OS/Node combinations | implementation and hosted matrix verified |
+| M2 | P0 portability rules | PS001/010/011/012/013/020/021/022/030/040 + the full v0.1 rule set | deterministic positive/negative fixtures and reviewed precision evidence | implementation and final matrix verified; ≥100 precision gate remains M8-open |
+| M3 | Reporter + explain | stylish/json/github reporters; rule docs; `explain` command | one command yields actionable findings; published JSON schemas are frozen | schemas/package contents verified; public npm publication pending |
+| M4 | Safe fixer | fix safety model, dry-run, cross-env/rimraf/shx conditional fixes | idempotency, concurrency, rollback, and recovery tests pass | recovery and race suites verified on hosted matrix |
+| M5 | Workspaces | npm/pnpm/Yarn/Bun discovery; PS040 workspace-bin awareness | real manager fixtures and a hosted 100-package benchmark under 2 seconds | manager fixtures and hosted 100-package benchmark verified |
+| M6 | GitHub Action | bundled Node Action + annotations + job summary; 3-OS matrix | immutable released reference runs in an external repository | bundled consumer, annotations, and 3-OS matrix verified; released reference pending |
+| M7 | Release | npm trusted publishing, provenance, release notes, checksums | one immutable tarball reaches npm and GitHub Release through Actions | workflow/recovery contracts and release PR CI verified; first release pending |
 | M8 | Validation and real corpus | read-only public scan, human sampling, false-positive ledger, public validation report | two-week gate, at least 100 reviewed findings, shared-corpus comparison, and real interest evidence | partial: first report merged in PR #64 |
 
 ## v0.1 validation gates (kill-or-commit)

--- a/docs/validation/spec-compliance-2026-09-01.md
+++ b/docs/validation/spec-compliance-2026-09-01.md
@@ -416,3 +416,33 @@
 ### 后续审计结论
 
 仓库内可修复的 correctness、安全、Action、schema、release recovery 与首页缺陷已经从基线的失败形态升级为有本地测试支撑的候选实现。由于 hosted、管理员、公开发布和外部证据仍有明确缺口，项目当前结论仍是 **NOT RELEASE READY**，而不是“全部 DoD PASS”。最终状态只应在[逐门核签账本](v0.1-dod-2026-09-01.md)列出的真实证据产生后更新。
+
+## 远程落地审计（2026-09-01，追加）
+
+本节是 append-only 的远程落地审计，只记录 2026-09-01 再核验时的 GitHub 与 npm 权威状态；不回写上文 212 项修复前基线，也不篡改前一节 hardening re-audit 的历史判断。远程工程、CI 与部分管理员控制已经闭合，但公开发布、floating alias 权限和 M8 外部/时间证据仍保持 OPEN。
+
+### 已闭合的远程工程与管理员项
+
+| 项目 | 状态 | 远程证据 |
+|---|---|---|
+| 远程审计基线 `main` | `CLOSED` | 本次核验时 `main` 为 [`4d34f86827dbb7a13b1300e317083aae64002ef2`](https://github.com/Tom409114/scriptspect/commit/4d34f86827dbb7a13b1300e317083aae64002ef2)；[PR #65](https://github.com/Tom409114/scriptspect/pull/65)、[#67](https://github.com/Tom409114/scriptspect/pull/67)、[#68](https://github.com/Tom409114/scriptspect/pull/68) 与 [#69](https://github.com/Tom409114/scriptspect/pull/69) 均已 merged。后续仅文档合入可使 `main` SHA 前进，不改变这条审计证据。 |
+| `main` hosted CI | `CLOSED` | push run [`33447746364`](https://github.com/Tom409114/scriptspect/actions/runs/33447746364) 在上述 exact `main` SHA 上 completed/success。 |
+| `main` 保护 | `CLOSED` | active branch ruleset [`21964571`](https://github.com/Tom409114/scriptspect/rules/21964571) 保护默认分支：要求 pull request、严格 required status checks、linear history，并禁止 deletion 与 non-fast-forward。 |
+| immutable version tag 保护 | `CLOSED（配置）` | active tag ruleset [`21964642`](https://github.com/Tom409114/scriptspect/rules/21964642) 匹配 `refs/tags/v*.*.*`，阻止 update 与 deletion。当前尚无正式 tag，因此这里只核签规则已落地，不把它表述为发布已完成。 |
+| environments 与 variables | `CLOSED（配置）` | `npm-bootstrap` 与 `release` environments 已创建并设置 required reviewer/branch policy；仓库变量为 `NPM_BOOTSTRAP_ENABLED=false`、`NPM_TRUSTED_PUBLISHING_READY=false`、`RELEASE_PR_ACTORS=github-actions[bot]`、`RELEASE_PR_CI_MODE=manual-approval`。两个 `false` 是正确的关闭态，不代表 npm bootstrap 或 Trusted Publisher 已完成。 |
+| workflow 供应链 | `CLOSED` | 当前所有第三方 GitHub Actions `uses:` 均固定到完整 commit SHA；本仓库内 Action 继续使用同 revision 的 `./`。 |
+| Dependabot | `CLOSED` | PR #68 将解析版本统一到 `esbuild 0.28.2`，已高于 advisory 的 first-patched `0.28.1`；原 low-severity alert #1 已 fixed，本次核验时 open Dependabot alerts 为 0。 |
+
+### 仍然 OPEN 的发布与外部证据项
+
+| 项目 | 状态 | 当前事实与关闭条件 |
+|---|---|---|
+| release PR | `OPEN` | 本次核验时 [PR #66](https://github.com/Tom409114/scriptspect/pull/66) 为 OPEN；head 为 `39a464752b1321464b474aa42682fddde5df7ea5`，mergeable state 为 `CLEAN`。其 CI run [`33447786827`](https://github.com/Tom409114/scriptspect/actions/runs/33447786827) 已 completed/success，16/16 jobs success；这关闭该快照的候选 CI 门禁，但不等于 PR 已合并或 release 已发布。后续 `main` 更新会让 release-please 刷新 head，届时必须以新 head 的 CI 为准。 |
+| npm package 与公开产物 | `PUBLICATION OPEN` | `npm view scriptspect` 仍返回 `E404`；Git tags 为 0，GitHub Releases 为 0。不存在 `scriptspect@0.1.0`、provenance、Release assets/checksum 或可消费的 released Action reference。 |
+| bootstrap contract / Trusted Publisher | `ADMIN + PUBLICATION OPEN` | 首次认领的独立 bootstrap 版本、`latest` 不移动证明、registry integrity contract、短期 token 撤销记录和 npm 侧 Trusted Publisher 配置尚未产生。准确 Trusted Publisher tuple 是 repository `Tom409114/scriptspect`、workflow **`npm-publish.yml`**、environment **`release`**、allowed action `npm publish`；不是 `release.yml`。只有配置完成并经真实 OIDC publish 验证后，才可把 `NPM_TRUSTED_PUBLISHING_READY` 设为 `true`。 |
+| floating aliases | `ADMIN OPEN` | ruleset `21964642` 只关闭 immutable `v*.*.*` 的 update/delete；当前没有 `v0`/`v0.*` floating policy 或 coordinator bypass actor。必须先落实并演练仅允许 coordinator 单调 CAS create/update、以及“此前不存在且同一发布失败”时窄范围 CAS delete 的权限路径，不能假设默认 `GITHUB_TOKEN` 可绕过 ruleset。 |
+| M8 / 外部与时间证据 | `EXTERNAL + TIME OPEN` | ≥100 条人工裁决与二次复核、同语料 scripts-doctor adjudication、两周窗口、独立试用/反馈、首次 onboarding 计时、真实 downstream，以及 30/60/90/180 天 KPI 仍需真实用户与时间产生；merged PR、green CI 和管理员配置不能替代这些证据。 |
+
+### 远程落地结论
+
+截至本次核验，hardening、修复 PR、准确 `main` hosted CI、主分支保护、immutable version tag update/delete 保护、environments/variables、Action SHA pinning 与 Dependabot 修复均已有远程落地证据；PR #66 也有准确 head 上 16/16 全绿且 CLEAN 的候选证据。但 npm 仍为 E404、tag/release 均为 0，bootstrap/Trusted Publisher、floating alias coordinator bypass 与 M8 外部/时间证据仍未关闭。因此当前判定仍是 **NOT RELEASE READY**，不得表述为“v0.1 已发布”“全部 DoD PASS”或“M0–M8 已完成”。

--- a/docs/validation/v0.1-dod-2026-09-01.md
+++ b/docs/validation/v0.1-dod-2026-09-01.md
@@ -1,19 +1,20 @@
 # ScriptSpect v0.1 Definition of Done 核签账本
 
 - 日期：2026-09-01
-- 基线：`main` at `d0650a7e232f720badec6f6be806c13f8e2fa25c`
-- 本次最终核签所验证的实现 HEAD：`feat/v0.1-hardening` at `dde44ea0e3459a2fe770a1701eb3bbc6146321a7`
+- 远程审计基线（本账本核验时）：`main` at `4d34f86827dbb7a13b1300e317083aae64002ef2`
+- 已合并实现链：[PR #65](https://github.com/Tom409114/scriptspect/pull/65)、[#67](https://github.com/Tom409114/scriptspect/pull/67)、[#68](https://github.com/Tom409114/scriptspect/pull/68)、[#69](https://github.com/Tom409114/scriptspect/pull/69)
+- 本次核验时保持开放的 release-please 候选：[PR #66](https://github.com/Tom409114/scriptspect/pull/66) at `39a464752b1321464b474aa42682fddde5df7ea5`
 - README/status 固定的已审阅 runtime/release source：`13dfcfcec3f50c3dd786a1f9b2a4225391ded0e5`
 - 设计依据：[v0.1 hardening design](../superpowers/specs/2026-09-01-scriptspect-v0.1-hardening-design.md)
 - 历史基线：[spec compliance baseline](spec-compliance-2026-09-01.md)
 
 ## 核签结论
 
-**结论：仓库实现已达到“本地候选”状态，但 ScriptSpect 尚未达到“可公开发布”或“v0.1 全部完成”状态。**
+**结论：仓库实现与本次审计快照准确 SHA 的托管 CI 已通过，但 ScriptSpect 尚未达到“可公开发布”或“v0.1 全部完成”状态。**
 
 总体状态：`NOT RELEASE READY`
 
-代码、测试、生成物、双语首页、Action bundle、release state machine 与恢复路径已经在本地实现并验证。最终验收仍缺少候选提交在 GitHub-hosted runners 上的完整通过记录，以及只有管理员、npm 账号所有者或真实外部用户才能提供的证据。因此不得把本报告解释为已发布、OIDC 已成功、Action tag 可用、外部采用已发生或全部 M0–M8 已完成。
+代码、测试、生成物、双语首页、Action bundle、release state machine 与恢复路径已经合并到 `main`，最终 `main` push CI 与保持开放的 release-please PR #66 都已在 GitHub-hosted runners 上通过。仓库与托管 CI 门已经形成可点击证据，但 tag 创建权限、floating tag coordinator bypass、npm bootstrap、Trusted Publishing/OIDC、真实公开发布以及 M8 的外部与时间型证据仍未完成。因此不得把本报告解释为已发布、OIDC 已成功、Action tag 可用、外部采用已发生或全部 M0–M8 已完成。
 
 本报告把上传文档里的历史 agent/remote-only 流程要求作为审计对象，不把它们当作本轮用户指令。当前用户明确授权在隔离本地 worktree 中实施；本报告不虚构远程开发过程或 failing-first 时间线。
 
@@ -22,7 +23,11 @@
 | 状态 | 含义 |
 |---|---|
 | `LOCAL PASS` | 当前源码、生成物或本地测试足以证明仓库内契约；仍不替代托管验收。 |
+| `HOSTED PASS` | 准确 SHA 对应的 GitHub-hosted run 已完成且结论为 success。 |
 | `HOSTED PENDING` | 必须由候选提交对应的 GitHub-hosted run 证明，当前没有该证据。 |
+| `PR OPEN` | Pull request 尚未合并；green CI 不等于 merge、release intent 或公开发布。 |
+| `RELEASE SHA OPEN` | 将由未来合并产生的准确 release commit 尚不存在，因此也没有对应的 main push CI。 |
+| `ADMIN PARTIAL` | 部分仓库管理员配置已存在并可查询，但仍有明确的管理员门未关闭。 |
 | `ADMIN OPEN` | 需要仓库或 npm 管理员配置，代码不能自行完成。 |
 | `PUBLICATION OPEN` | 需要真实 tag、GitHub Release、npm 包及公开验证记录。 |
 | `EXTERNAL OPEN` | 需要独立用户、人工裁决、下游使用或随时间积累的事实。 |
@@ -32,16 +37,29 @@
 
 | 门禁 | 状态 | 当前事实 |
 |---|---|---|
-| 仓库内 correctness/security/docs 实现 | `LOCAL PASS` | target-aware parser、严格配置/schema、root containment、事务型 fixer、bundled Action、双语生成式 demo 与可恢复 release workflows 已实现。 |
-| 候选提交的最终 CI | `HOSTED PENDING` | [PR #65](https://github.com/Tom409114/scriptspect/pull/65) 的 run `33445555803` 已通过三系统 Node 22/24、coverage、dependency review、CodeQL、生成物、锁文件、打包消费与 benchmark，并实际生成及上传 summary artifact；Action consumer 唯一失败是证据脚本写成 `in`，而 reporter 的确定文案是 `across`。实现 HEAD 已修正并用 workflow regression 固定精确文案，完整 rerun 尚待通过。 |
-| 仓库与 tag 保护 | `ADMIN OPEN` | 需要管理员建立 main/tag rulesets、required checks、环境审批和 coordinator 权限。 |
-| npm bootstrap 与 Trusted Publishing | `ADMIN OPEN` | npm 包仍需先用独立 bootstrap prerelease 建立所有权和完整性契约，再配置 OIDC。 |
+| 仓库内 correctness/security/docs 实现 | `LOCAL PASS / HOSTED PASS` | target-aware parser、严格配置/schema、root containment、事务型 fixer、bundled Action、双语生成式 demo 与可恢复 release workflows 已合并；`main` run [`33447746364`](https://github.com/Tom409114/scriptspect/actions/runs/33447746364) 在 `4d34f86827dbb7a13b1300e317083aae64002ef2` 上 success。 |
+| release-please 候选 CI | `HOSTED PASS / PR OPEN` | PR #66 head `39a464752b1321464b474aa42682fddde5df7ea5` 的 run [`33447786827`](https://github.com/Tom409114/scriptspect/actions/runs/33447786827) 为 16/16 jobs success；PR 有意保持 OPEN，不能把 green CI 等同于已合并或已发布。 |
+| 仓库与 tag 保护 | `ADMIN PARTIAL` | `main` ruleset `21964571` 与 semantic-version tag no-update/delete ruleset `21964642` 均 active；`npm-bootstrap`、`release` environments 及 owner approval 已建立。semantic tag 创建限制、floating `v0`/`v0.*` policy 与 coordinator bypass/permission drill 仍 OPEN。 |
+| npm bootstrap 与 Trusted Publishing | `ADMIN OPEN` | 四个仓库变量处于安全关闭态；npm 包仍需用独立 bootstrap prerelease 建立所有权和完整性契约，再配置并公开验证 OIDC。 |
 | v0.1.0 正式发布 | `PUBLICATION OPEN` | 尚无经过本管线验证的 npm `0.1.0`、GitHub Release、checksum、provenance 或 Action tags。 |
 | 精度、比较、onboarding 与 adoption | `EXTERNAL OPEN` | 人工裁决、独立试用、真实下游和时间型 KPI 均未完成，不以自有 fixture 替代。 |
 
-## 本地核验证据
+## 2026-09-01 远程审计快照
 
-以下是本轮在共享 worktree 中实际完成的本地验证记录；它们证明实现质量，但不冒充托管 CI：
+以下状态于 2026-09-01 通过 GitHub 的 repository、pull request、Actions、rulesets、environments、variables 与 Dependabot API 复核；它们取代修复前“PR #65 尚待推送/hosted pending/尚无保护”的候选叙述。文档合入本身会使 `main` 与 release-please head 前进，所以 SHA/run 是可复核的审计快照，不是对未来 head 的预证明：
+
+- [PR #65](https://github.com/Tom409114/scriptspect/pull/65) 已合并为 `5e85cb4c8f7ad1637dbc1779d3ba7d247379a864`；后续 [PR #67](https://github.com/Tom409114/scriptspect/pull/67)、[#68](https://github.com/Tom409114/scriptspect/pull/68)、[#69](https://github.com/Tom409114/scriptspect/pull/69) 也已依次合并，本次审计基线 `main` 为 `4d34f86827dbb7a13b1300e317083aae64002ef2`。
+- 准确 `main` SHA 的最终 push CI run [`33447746364`](https://github.com/Tom409114/scriptspect/actions/runs/33447746364) 已 completed/success；push 事件按设计跳过 Dependency review，其余 15 jobs success，workflow 总结论仍为 success。
+- [PR #66](https://github.com/Tom409114/scriptspect/pull/66) 是保持开放的 `chore(main): release 0.1.0` release-please PR；本次核验时 head `39a464752b1321464b474aa42682fddde5df7ea5` 的 run [`33447786827`](https://github.com/Tom409114/scriptspect/actions/runs/33447786827) 已 16/16 jobs success。OPEN 是当前发布门控状态，不是 hosted 验证失败；后续 head 更新必须重新验证。
+- `main` ruleset [`21964571`](https://github.com/Tom409114/scriptspect/rules/21964571) 已 active，覆盖默认分支，禁止删除/non-fast-forward，要求 pull request、线性历史、解决 review threads、strict required checks，并固定当前 16 个稳定 check names。
+- semantic-version tag ruleset [`21964642`](https://github.com/Tom409114/scriptspect/rules/21964642) 已 active，匹配 `refs/tags/v*.*.*` 并禁止 update/deletion。它没有 creation rule、没有 bypass actor，也不覆盖 floating `v0`/`v0.*`，所以不得把 tag 创建权限或 coordinator alias 权限视为已完成。
+- `npm-bootstrap` 与 `release` environments 已建立，均配置 owner `Tom409114` 的 required reviewer 和 custom branch policy；这证明环境审批存在，不证明 npm 所有权、bootstrap 或 OIDC 已完成。
+- 四个 repository variables 处于安全关闭态：`NPM_BOOTSTRAP_ENABLED=false`、`NPM_TRUSTED_PUBLISHING_READY=false`、`RELEASE_PR_CI_MODE=manual-approval`、`RELEASE_PR_ACTORS=github-actions[bot]`。因此当前配置不会把 bootstrap、Trusted Publishing 或无人值守 release PR 错当作已启用。
+- repository Actions policy 的 `sha_pinning_required` 为 `true`；Dependabot alert #1（development transitive `esbuild`）已由 PR #68 修复，状态为 `fixed`。
+
+## 历史本地核验证据
+
+以下是合并前在共享 worktree 中实际完成的本地验证记录；它们证明当时候选的实现质量。上面的 GitHub-hosted 证据现已补齐，但本节仍作为历史账本保留，不把旧本地命令改写成事后重新运行：
 
 - `corepack pnpm@11.24.0 install --frozen-lockfile`：通过。
 - schema、规则文档、README demo、README status 与双语 parity 生成检查：通过。
@@ -54,7 +72,7 @@
 - Action 定向回归：3 个 test files、17 tests 通过；bundle 在无 `node_modules` 的隔离消费场景以及文件系统 alias entrypoint 下均可运行。
 - `actionlint 1.7.12 -shellcheck=`：除它尚未识别 GitHub 当前官方 `concurrency.queue: max` 字段外无诊断；仅对该精确 schema-lag 消息使用窄 ignore 后 exit 0。`queue: max` 由仓库测试解析并保留，不能为了迁就旧 linter 删除；此命令仍明确关闭了 shellcheck。
 
-本地 actionlint 与 workflow contract tests 已证明除上述新字段外的 YAML/expression 契约；首轮 GitHub hosted run 已实际解析并执行含 `queue: max` 的 workflows。完整 shellcheck 没有形成可接受的成功证据，因此本报告不把 shell 检查标为通过；应在 Linux hosted validation 中补齐。最终候选提交产生后，上述本地数字也必须重新执行，不能沿用为新 commit 的证明。
+本地 actionlint 与 workflow contract tests 已证明除上述新字段外的 YAML/expression 契约；后续 successful GitHub-hosted runs 已实际解析并执行含 `queue: max` 的 workflows。当前 required CI 并没有一个名为 shellcheck 的独立 check，因此本报告仍不把“完整 shellcheck”写成已通过；这项历史本地限制也不能反向改写。上面的本地数字绑定合并前候选，不能冒充 `main` 或 PR #66 的重新运行结果；这些 SHA 的结论以各自 hosted run 为准。
 
 本报告自身使用 `git diff --check`、trailing-whitespace assertion、13 个 DoD 行/状态词 assertion 和相对链接存在性检查进行核验。仓库没有可用的 Markdown formatter/linter；对这两个路径运行 Biome 会显示 `Checked 0 files`，因此没有把该结果误记为 Markdown lint 通过。
 
@@ -62,19 +80,19 @@
 
 | ID | 核签状态 | 当前证据 | 仍需完成 |
 |---|---|---|---|
-| DOD-01 | `HOSTED PENDING` | [CI workflow](../../.github/workflows/ci.yml) 已定义 frozen install、90% coverage、三 OS × Node 22/24、packed consumer、真实 `uses: ./`、hosted annotations、dependency review、CodeQL 与 100-package benchmark。 | 在最终 PR 的准确候选 SHA 上全部 hosted checks 通过并设为 required；本地结果不是最终验收。 |
+| DOD-01 | `HOSTED PASS / RELEASE SHA OPEN` | [CI workflow](../../.github/workflows/ci.yml) 定义的 frozen install、90% coverage、三 OS × Node 22/24、packed consumer、真实 `uses: ./`、hosted annotations、dependency review、CodeQL 与 100-package benchmark，已在 `main` run `33447746364` success；PR #66 head run `33447786827` 为 16/16 success。main ruleset `21964571` 已把 16 个稳定 check names 设为 required。 | PR #66 仍 OPEN；若合并产生新的 release commit，仍须在那个准确 main SHA 上取得 successful push CI，当前两个 green runs 不能预证明尚不存在的 merge SHA。 |
 | DOD-02 | `UNVERIFIABLE`（历史流程） | 本轮按用户明确授权在隔离 worktree 中开发；上传文档里的“不得在用户本地开发”是被审计的历史流程要求。 | 不虚构 remote-only 轨迹。如维护者仍要求该历史流程，需由远程 commit/PR/audit log 另行证明。 |
-| DOD-03 | `LOCAL PASS` | 新增 PS051 具备 registry metadata、target-aware 正负/边界 fixtures、三类显式 negative cases 与[生成规则文档](../rules/PS051.md)；registry/docs consistency 由测试覆盖。 | 最终 PR 运行一致性与生成物检查。 |
+| DOD-03 | `LOCAL PASS / HOSTED PASS` | 新增 PS051 具备 registry metadata、target-aware 正负/边界 fixtures、三类显式 negative cases 与[生成规则文档](../rules/PS051.md)；registry/docs consistency 由测试覆盖，PR #66 的 `Generated files are current` 与 `Quality and coverage` 均 success。 | 仓库控制范围内已闭环；正式发布后的公共包仍按 DOD-06/07 另行验证。 |
 | DOD-04 | `LOCAL PASS / HISTORICAL UNVERIFIABLE` | parser、config、manifest、fixer races/faults、Action、release recovery 都已有回归测试。 | 仓库最终状态能证明 regression 存在，不能单独证明每个 bug 都严格先红后绿；如需该过程证据，保留 PR 时间线或 failing commit。 |
-| DOD-05 | `LOCAL PASS` | [transaction tests](../../tests/fixers/transaction.test.ts)、[race tests](../../tests/fixers/transaction-races.test.ts)、fault、CLI verification 与 idempotency tests 覆盖 containment、inode/hardlink/race、crash recovery、rollback 和 manual recovery。 | 最终三平台 hosted suite，尤其 POSIX symlink 与 Windows filesystem 行为。 |
+| DOD-05 | `LOCAL PASS / HOSTED PASS` | [transaction tests](../../tests/fixers/transaction.test.ts)、[race tests](../../tests/fixers/transaction-races.test.ts)、fault、CLI verification 与 idempotency tests 覆盖 containment、inode/hardlink/race、crash recovery、rollback 和 manual recovery；main 与 PR #66 的三 OS × Node 22/24 matrix 均通过。 | 当前仓库控制范围内已闭环；未来 release commit 仍需自己的 exact-SHA CI。 |
 | DOD-06 | `LOCAL PASS / PUBLICATION OPEN` | README 的 before/output/patch/after 由单一 fixture 生成；[homepage tests](../../tests/docs/readme-homepage.test.ts) 与 parity checker 防漂移；pre-release 页面只给 source evaluation。 | npm 发布后才能切换并验证公共 `npx`/`pnpm dlx` quick start；不可提前声称 registry 命令可用。 |
 | DOD-07 | `LOCAL PASS` | [config/output schemas](../../schema) 由 runtime registry/contract 生成；[schema parity tests](../../tests/config/schema-contract.test.ts) 验证 runtime 与 JSON Schema，并验证实际 JSON report 的 `schemaVersion`。 | npm tarball 与 unpkg 公共 URL 在正式发布后验证。 |
-| DOD-08 | `LOCAL PASS / HOSTED PENDING` | lockfile-frozen installs、pnpm pin、full-SHA Actions、runtime dependency budget、read-only PR policy 与 release provenance checks 已由 source tests 约束。 | 最终 PR 的 dependency review、CodeQL、Action/workflow policy 与 hosted Linux shell validation 通过。 |
-| DOD-09 | `PR OPEN / HOSTED PENDING` | [PR #65](https://github.com/Tom409114/scriptspect/pull/65) 已记录 scope、风险、测试、语义与 rollback；变更按可审阅 commits 拆分，两轮 hosted 反馈均已转化为回归修复。 | 推送当前候选并取得全部 green checks 后再合并；旧 PR #62 应由 #65 取代。 |
+| DOD-08 | `LOCAL PASS / HOSTED PASS` | lockfile-frozen installs、pnpm pin、runtime dependency budget、read-only PR policy 与 release provenance checks 已由 source tests 约束并随 main/PR #66 CI 通过；repository Actions policy 的 `sha_pinning_required=true`，PR #66 的 Dependency review 与 CodeQL 均 success，Dependabot #1 已 fixed。 | 正式 release commit 仍须通过 exact-SHA main CI；没有独立 shellcheck check，故不得另称完整 shellcheck 已通过。 |
+| DOD-09 | `IMPLEMENTATION MERGED / RELEASE PR OPEN` | [PR #65](https://github.com/Tom409114/scriptspect/pull/65) 及修复 [#67](https://github.com/Tom409114/scriptspect/pull/67)、[#68](https://github.com/Tom409114/scriptspect/pull/68)、[#69](https://github.com/Tom409114/scriptspect/pull/69) 均已合并；当前 `main` CI success。[PR #66](https://github.com/Tom409114/scriptspect/pull/66) head CI 16/16 success，但 PR 仍 OPEN。 | 在 tag 创建/floating bypass、npm bootstrap、OIDC 与发布前置门完成前保持 PR #66 OPEN；不得为追求“全部已合并”的表象提前触发正式 release intent。 |
 | DOD-10 | `LOCAL PASS / EXTERNAL OPEN` | [public-claims tests](../../tests/docs/public-claims.test.ts)、双语首页与 roadmap 禁止虚构 release、v1 tag、milestone、precision、benchmark superiority 和 adoption。 | 任何外部数字只有在可点击、独立且复现的证据产生后才能发布。 |
 | DOD-11 | `LOCAL PASS / UNVERIFIABLE OUTSIDE TREE` | corpus workflow 只读；PR CI 无 third-party write；本轮没有向第三方仓库写 issue/PR/comment。 | 仓库外历史人工行为无法由 tree 证明；未来第三方写操作继续要求单独授权和活动记录。 |
 | DOD-12 | `LOCAL PARTIAL / EXTERNAL OPEN` | [comparison harness](../../tools/comparison/run.ts) 在同一 owned fixture corpus 上固定 `scripts-doctor@1.0.0`、commands、outputs、hashes 与 adjudication schema，且明确 `promotable: false`。 | 完成人工裁决、固定 hosted environment 与可复现报告前，不得宣称胜出；后续竞品变化需更新研究。 |
-| DOD-13 | `REPORT COMPLETE / OVERALL OPEN` | 本文件完成逐门核签，并把 hosted/admin/publication/external 门明确保留为未完成。 | 只有 DOD-01、09 及所有管理员、发布和适用外部门禁取得真实证据后，才能把总体结论改为完成。 |
+| DOD-13 | `REPORT COMPLETE / OVERALL OPEN` | 本文件完成逐门核签：当前 main 与 release PR hosted CI、main ruleset、immutable semantic-tag update/delete protection、environment approvals、SHA pinning 与 Dependabot 修复已有远程证据；未完成项仍单独列出。 | PR #66 的 eventual merge-SHA CI、tag creation/floating coordinator 权限、npm bootstrap/OIDC、公开发布与适用的 M8 外部证据取得真实记录后，才能重新判断总体结论；当前仍是 `NOT RELEASE READY`。 |
 
 ## 仓库内已关闭的主要缺陷簇
 
@@ -86,27 +104,29 @@
 6. **CI 与 release code**：PR jobs 最小权限、frozen lock、真实 Action/package consumers 与 coverage/benchmark gates；无环境权限的 intent discovery 先让普通 main CI 安全短路，只有精确 release-please intent 才申请发布审批。coordinator 持久化唯一候选和四个预最终资产，再以 exact tag 显式 dispatch OIDC publisher。发布器按评审过的 exact/canonical 完整性模式验证真实 registry bytes，用 executable-source digest 绑定 comparator，以有界退避处理传播；`alias-planned`/`final-planned`、全局 publisher lock、per-SHA state lock、Latest 单调判断和精确 CAS rollback 关闭并发、重试与崩溃窗口。
 7. **首页与证据**：中英双版可切换，单一 fixture 生成真实 demo，pre-release 状态不展示不存在的 npm/Action 命令；corpus 保存 immutable locators/hashes，comparison 不自动宣布胜负。
 
-## 尚未关闭的托管与管理员门
+## 已关闭与仍开放的远程门
 
 ### GitHub-hosted validation
 
-1. 推送当前最终候选到 [PR #65](https://github.com/Tom409114/scriptspect/pull/65)；不要合并旧 PR #62 来替代这批修复。
-2. 在候选 SHA 上通过 CI 中所有稳定 check names，包括三 OS × Node 22/24、coverage、package consumer、`uses: ./`、annotations/summary、CodeQL、dependency review 与 hosted benchmark。
-3. 在 Linux hosted 环境重新完成 Action/workflow syntax，并补齐 shell validation；本地 actionlint 明确禁用了 shellcheck，不能替代该门禁。
-4. 合并后，在准确 main SHA 上再次通过 push CI；发布流程只接受该 exact successful run。
+1. PR #65 不再是“待推送候选”：它与 PR #67/#68/#69 均已合并，本次审计基线 `main` 已前进到 `4d34f86827dbb7a13b1300e317083aae64002ef2`。
+2. 该审计基线 `main` 的 exact-SHA push CI run `33447746364` 已 success；PR #66 快照 head `39a464752b1321464b474aa42682fddde5df7ea5` 的 run `33447786827` 已 16/16 success。对这两个已验证 SHA，不再使用 `HOSTED PENDING`。
+3. PR #66 保持 OPEN。若管理员稍后合并它，新的 main merge SHA 必须再次通过 exact successful push CI；现在的 main run 与 PR-head run 都不能代替未来 merge SHA 的 release coordinator 输入。
+4. 本地 actionlint 的窄 schema-lag 例外与禁用 shellcheck 仍按历史事实保留；successful hosted workflow 证明当前 YAML 被 GitHub 接受并执行，但本报告不虚构一个仓库中不存在的独立 shellcheck check。
 
 ### Repository administration
 
-1. 为 `main` 建立 required pull request/checks、禁止 force push/delete 的 ruleset，并记录 ruleset ID 与 check names。
-2. 为 immutable `v*.*.*` 与 floating `v0`/`v0.*` 建立不重叠的 tag policies；不可变版本 tag 禁止更新/删除，floating policy 仅允许 coordinator 做单调 CAS 更新，以及在首次创建后同一 release 的后续失败中 CAS 删除到“原先不存在”的状态。记录 actor、ruleset IDs 与 non-production permission drill。
-3. 创建 `npm-bootstrap` 与 `release` GitHub environments，设置审批人。
-4. 首次认领期间设置 `NPM_BOOTSTRAP_ENABLED=true`，只在 `npm-bootstrap` environment 放置短期 granular `NPM_BOOTSTRAP_TOKEN`；bootstrap 成功后提交并审阅完整性契约，随后撤销 token、删除 secret，并将开关设回 `false`。
-5. 设置 `NPM_TRUSTED_PUBLISHING_READY=true` 之前，先完成下方 npm Trusted Publisher 配置。
-6. Release PR 默认可使用 manual approval；若启用无人值守模式，安装最小权限 GitHub App，仅授予 contents/pull-requests write，并配置 actor allowlist。
+1. **已完成：** `main` ruleset `21964571` active，required pull request/checks、线性历史、review-thread resolution、禁止 force push/delete 均已配置；“没有 branch protection”已不是当前事实。
+2. **已完成但范围有限：** semantic-version tag ruleset `21964642` active，`refs/tags/v*.*.*` 禁止 update/deletion，足以支持“已创建的 semantic version tag 不可移动或删除”这一窄结论。
+3. **仍 OPEN：** ruleset `21964642` 没有 creation rule 或 bypass actor；仓库也没有覆盖 floating `v0`/`v0.*` 的第二条 tag ruleset。管理员仍须把 semantic tag 创建限制到 coordinator，并为 floating aliases 建立不重叠 policy，只允许 coordinator 做单调 CAS update，以及在规定恢复窗口中做精确 CAS deletion；随后记录 coordinator actor、ruleset ID 与 non-production permission drill。
+4. **已完成：** `npm-bootstrap` 与 `release` environments 已创建并配置 owner approval；环境存在不等于相关发布动作已经运行。
+5. **当前安全关闭：** `NPM_BOOTSTRAP_ENABLED=false`、`NPM_TRUSTED_PUBLISHING_READY=false`、`RELEASE_PR_CI_MODE=manual-approval`、`RELEASE_PR_ACTORS=github-actions[bot]`。不要为了关闭文档门禁而提前翻转这些值。
+6. **仍 OPEN：** 首次认领期间才可临时设置 `NPM_BOOTSTRAP_ENABLED=true`，只在 `npm-bootstrap` environment 放置短期 granular `NPM_BOOTSTRAP_TOKEN`；bootstrap 成功并提交、审阅完整性契约后，撤销 token、删除 secret，并把开关恢复为 `false`。
+7. **仍 OPEN：** 完成下方 npm Trusted Publisher 准确绑定并取得可验证证据后，才可设置 `NPM_TRUSTED_PUBLISHING_READY=true`。当前 `false` 是正确的安全状态，不是待掩盖的失败。
+8. **当前采用人工门控：** release PR 模式是 `manual-approval`。若未来改用无人值守模式，仍需安装最小权限 GitHub App（仅 contents/pull-requests write）并配置 actor allowlist；当前不得声称 coordinator bypass 或 unattended mode 已就绪。
 
 ### npm Trusted Publisher 的准确绑定
 
-正式发布必须绑定独立的 exact-tag publisher，而不是候选构建 workflow：
+当前状态仍为 `ADMIN OPEN`：`release` environment 与 owner approval 已存在、`NPM_TRUSTED_PUBLISHING_READY=false` 也正确 fail closed，但尚无 bootstrap ownership/integrity contract 或公开 OIDC provenance。正式发布必须绑定独立的 exact-tag publisher，而不是候选构建 workflow：
 
 | npm 设置字段 | 准确值 |
 |---|---|
@@ -128,8 +148,10 @@
 - scripts-doctor 同语料人工 adjudication；未完成前 comparison 保持 non-promotable。
 - 独立试用/反馈、首次 onboarding 计时、真实 downstream、月度 evidence 与 30/60/90/180 天 KPI；这些只能由真实用户和时间产生。
 
+因此 M8 的只读 corpus/scanner 与方法论代码虽已合并并通过当前 CI，M8 的人工精度裁决、独立 comparison、外部试用、真实 downstream 与时间型 adoption 验收仍为 `EXTERNAL OPEN`；不得把“代码存在”改写成“M8 完成”。
+
 ## 最终判定
 
-当前状态可以表述为：**“v0.1 hardening 的仓库实现已通过本地工程核验，正在等待 hosted PR、管理员 bootstrap/OIDC 与真实发布验证。”**
+当前状态可以表述为：**“v0.1 hardening 已合并到 `main`，当前 main 与保持 OPEN 的 release PR #66 均有 successful hosted CI；仓库保护已部分落地，仍等待 tag creation/floating coordinator 权限、npm bootstrap/OIDC、准确 release-merge SHA、真实公开发布与 M8 外部验收。”**
 
 当前状态不得表述为：**“release ready”“v0.1 已发布”“OIDC 已配置”“Action `@v0.1` 可用”“M0–M8 全部完成”或“已有外部采用”。**


### PR DESCRIPTION
## Summary`n- refresh the roadmap against the merged hardening and hosted CI evidence`n- append an audit snapshot to the compliance report without rewriting the historical baseline`n- update the v0.1 DoD ledger while keeping npm publication, tag actor, and M8 gates explicitly open`n`n## Verification`n- corepack pnpm@11.24.0 install --frozen-lockfile`n- corepack pnpm@11.24.0 test (55 files, 600 passed, 6 skipped)`n- corepack pnpm@11.24.0 typecheck`n- corepack pnpm@11.24.0 lint`n- corepack pnpm@11.24.0 audit --audit-level=low`n- git diff --check`n`n## Safety`nThis PR changes documentation only. It does not merge the release PR, create tags or releases, publish to npm, or change release gates.