### PR TITLE
ci: upgrade artifact uploads to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
           grep -Fx 'exit-code=0' "$RUNNER_TEMP/action-summary-output.txt"
       - name: Upload hosted Action summary evidence
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: action-consumer-evidence-${{ github.run_id }}
           path: |
@@ -276,7 +276,7 @@ jobs:
             --arg summarySha256 "$(sha256sum "$SUMMARY_FILE" | cut -d' ' -f1)" \
             '{workflowRunId: $workflowRunId, jobId: $jobId, checkRunId: $checkRunId, annotationCount: $annotationCount, summarySha256: $summarySha256}' \
             > "$RUNNER_TEMP/action-runner-evidence.json"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: action-runner-evidence-${{ github.run_id }}
           path: ${{ runner.temp }}/action-runner-evidence.json
@@ -315,7 +315,7 @@ jobs:
           SCRIPTSPECT_SOURCE_COMMIT: ${{ github.sha }}
         run: pnpm exec tsx tools/benchmark-workspace.ts "$RUNNER_TEMP/workspace-benchmark.json" 100 2000
       - name: Upload hosted benchmark evidence
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: workspace-benchmark-${{ github.sha }}
           path: ${{ runner.temp }}/workspace-benchmark.json

--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -122,7 +122,7 @@ jobs:
           fi
       - name: Upload draft evidence for maintainer review
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: corpus-draft-${{ github.run_id }}
           path: |

--- a/.github/workflows/npm-bootstrap.yml
+++ b/.github/workflows/npm-bootstrap.yml
@@ -135,7 +135,7 @@ jobs:
           ' > "$RUNNER_TEMP/bootstrap/bootstrap-anchor.json"
       - name: Persist the exact bootstrap candidate before npm publication
         if: steps.anchor.outputs.recovered != 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: npm-bootstrap-anchor-${{ inputs.version }}-${{ inputs.source-sha }}
           path: |
@@ -298,7 +298,7 @@ jobs:
               ]
             }' > "$RUNNER_TEMP/bootstrap/bootstrap-integrity-contract.json"
       - name: Retain bootstrap evidence for maintainer review
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: npm-bootstrap-evidence-${{ inputs.version }}
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -455,7 +455,7 @@ jobs:
       - name: Retain the candidate before creating tags or releases
         if: steps.recover.outputs.needs-build == 'true'
         id: candidate-upload
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-candidate-${{ needs.authorize.outputs.version }}-${{ github.run_id }}
           path: ${{ runner.temp }}/candidate

--- a/tests/workflows/ci-policy.test.ts
+++ b/tests/workflows/ci-policy.test.ts
@@ -132,6 +132,30 @@ describe('pull-request trust boundary', () => {
       }
     }
   });
+
+  it('pins artifact actions to reviewed Node 24 releases', () => {
+    const approved: Record<string, string> = {
+      'actions/upload-artifact': '043fb46d1a93c77aae656e7c1c64a875d1fc6a0a', // v7.0.1
+      'actions/download-artifact': '3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c', // v8.0.1
+    };
+    const usages: Array<{ action: string; workflow: string; uses: string }> = [];
+
+    for (const name of workflowNames()) {
+      for (const step of allSteps(workflow(name))) {
+        const action = Object.keys(approved).find((candidate) =>
+          step.uses?.startsWith(`${candidate}@`),
+        );
+        if (action && step.uses) {
+          usages.push({ action, workflow: name, uses: step.uses });
+        }
+      }
+    }
+
+    expect(usages.length).toBeGreaterThan(0);
+    for (const usage of usages) {
+      expect(usage.uses, usage.workflow).toBe(`${usage.action}@${approved[usage.action]}`);
+    }
+  });
 });
 
 describe('reproducible CI', () => {


### PR DESCRIPTION
## Summary`n- replace all seven upload-artifact v4.6.2/Node 20 pins with official v7.0.1/Node 24 at full SHA 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`n- preserve the existing ZIP upload semantics; none of these jobs enables the new direct-upload mode`n- add an exact allowlist regression for reviewed Node 24 upload/download artifact Action revisions`n`n## Evidence`nThe previous hosted CI emitted Node.js 20 deprecation annotations for every artifact upload. The new official action.yml declares runs.using: node24.`n`n## Verification`n- failing-first ci-policy regression reproduced all old pins`n- corepack pnpm@11.24.0 test (55 files, 601 passed, 6 skipped)`n- corepack pnpm@11.24.0 typecheck`n- corepack pnpm@11.24.0 lint`n- corepack pnpm@11.24.0 audit --audit-level=low`n- git diff --check`n`n## Safety`nThis does not merge the release PR, create tags/releases, publish to npm, or change readiness gates.