### PR TITLE
docs(homepage): showcase verified Action results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
           corepack prepare pnpm@11.24.0 --activate
           pnpm install --frozen-lockfile
       - name: Regenerate schemas, rule docs, and bilingual demo assets
+        env:
+          SOURCE_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
         run: |
           pnpm exec tsx tools/generate-schemas.ts
           pnpm docs:rules
@@ -59,8 +61,15 @@ jobs:
           git cat-file -e "$STATUS_COMMIT^{commit}"
           git merge-base --is-ancestor "$STATUS_COMMIT" HEAD
           test "$STATUS_COMMIT" != "$(git rev-parse HEAD)"
-          git diff --quiet "$STATUS_COMMIT" HEAD -- \
-            src dist schema package.json pnpm-lock.yaml pnpm-workspace.yaml action.yml tsconfig.json tsup.config.ts
+          git cat-file -e "$SOURCE_BASE^{commit}"
+          if ! git diff --quiet "$SOURCE_BASE" HEAD -- \
+            docs/readme-status.json \
+            docs/validation/readme-action-evidence.json \
+            README.md \
+            README.zh-CN.md; then
+            git diff --quiet "$STATUS_COMMIT" HEAD -- \
+              src dist schema package.json pnpm-lock.yaml pnpm-workspace.yaml action.yml tsconfig.json tsup.config.ts
+          fi
           git diff --exit-code -- \
             schema \
             docs/rules \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           git merge-base --is-ancestor "$STATUS_COMMIT" HEAD
           test "$STATUS_COMMIT" != "$(git rev-parse HEAD)"
           git diff --quiet "$STATUS_COMMIT" HEAD -- \
-            src dist schema package.json pnpm-lock.yaml action.yml tsconfig.json tsup.config.ts
+            src dist schema package.json pnpm-lock.yaml pnpm-workspace.yaml action.yml tsconfig.json tsup.config.ts
           git diff --exit-code -- \
             schema \
             docs/rules \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
         env:
           SOURCE_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
         run: |
+          set -o pipefail
           pnpm exec tsx tools/generate-schemas.ts
           pnpm docs:rules
           pnpm exec tsx tools/generate-readme-demo.ts
@@ -62,14 +63,44 @@ jobs:
           git merge-base --is-ancestor "$STATUS_COMMIT" HEAD
           test "$STATUS_COMMIT" != "$(git rev-parse HEAD)"
           git cat-file -e "$SOURCE_BASE^{commit}"
-          if ! git diff --quiet "$SOURCE_BASE" HEAD -- \
+          set +e
+          git diff --quiet "$SOURCE_BASE" HEAD -- \
             docs/readme-status.json \
             docs/validation/readme-action-evidence.json \
             README.md \
-            README.zh-CN.md; then
-            git diff --quiet "$STATUS_COMMIT" HEAD -- \
-              src dist schema package.json pnpm-lock.yaml pnpm-workspace.yaml action.yml tsconfig.json tsup.config.ts
-          fi
+            README.zh-CN.md
+          SOURCE_DIFF=$?
+          set -e
+          case "$SOURCE_DIFF" in
+            0)
+              PINNED_SOURCE_DIR="$RUNNER_TEMP/readme-pinned-source"
+              mkdir -p "$PINNED_SOURCE_DIR"
+              git archive "$STATUS_COMMIT" | tar -x -C "$PINNED_SOURCE_DIR"
+              (
+                cd "$PINNED_SOURCE_DIR"
+                corepack pnpm install --frozen-lockfile
+                corepack pnpm exec tsx tools/generate-readme-demo.ts
+              )
+              for PINNED_ASSET in \
+                package.before.json \
+                terminal.txt \
+                fix.patch \
+                package.after.json \
+                terminal.svg; do
+                git diff --no-index --exit-code -- \
+                  "$PINNED_SOURCE_DIR/docs/assets/demo/$PINNED_ASSET" \
+                  "docs/assets/demo/$PINNED_ASSET"
+              done
+              ;;
+            1)
+              git diff --quiet "$STATUS_COMMIT" HEAD -- \
+                src dist schema package.json pnpm-lock.yaml pnpm-workspace.yaml action.yml tsconfig.json tsup.config.ts
+              ;;
+            *)
+              echo "::error::unable to compare README source metadata with the event base"
+              exit "$SOURCE_DIFF"
+              ;;
+          esac
           git diff --exit-code -- \
             schema \
             docs/rules \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,8 @@ jobs:
           git cat-file -e "$STATUS_COMMIT^{commit}"
           git merge-base --is-ancestor "$STATUS_COMMIT" HEAD
           test "$STATUS_COMMIT" != "$(git rev-parse HEAD)"
-          git diff-tree --root --no-commit-id --name-only -r "$STATUS_COMMIT" -- src package.json action.yml \
-            | grep -Eq '^(src/|package\.json$|action\.yml$)'
+          git diff --quiet "$STATUS_COMMIT" HEAD -- \
+            src dist schema package.json pnpm-lock.yaml action.yml tsconfig.json tsup.config.ts
           git diff --exit-code -- \
             schema \
             docs/rules \

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 [English](README.md) | [简体中文](README.zh-CN.md)
 
 <p align="center">
-  <img src="docs/assets/brand/hero.svg" width="100%" alt="ScriptSpect analyzes package scripts for POSIX shell, Windows cmd, and PowerShell portability problems before the scripts run">
+  <picture>
+    <source media="(max-width: 700px)" srcset="docs/assets/brand/hero-mobile.svg">
+    <img src="docs/assets/brand/hero.svg" width="100%" alt="ScriptSpect analyzes package scripts for POSIX shell, Windows cmd, and PowerShell portability problems before the scripts run">
+  </picture>
 </p>
 
 <p align="center">
@@ -34,27 +37,6 @@ ScriptSpect uses a target-specific structural parser rather than scanning quoted
 text with a stack of regular expressions. It is intentionally not a full shell
 interpreter: findings should still be reviewed in the project that owns the
 script.
-
-<!-- readme-section: evaluate -->
-## Evaluate from source (pre-release)
-
-Requires Node.js 22 or newer and pnpm via Corepack. Clone the repository, check
-out the reviewed commit, install exactly from the lockfile, build, and scan the
-versioned demo fixture. Findings exit `1`; a clean scan exits `0`; invalid input,
-configuration, or I/O exits `2`.
-
-```bash
-git clone https://github.com/Tom409114/scriptspect.git
-cd scriptspect
-git checkout 13dfcfcec3f50c3dd786a1f9b2a4225391ded0e5
-corepack enable
-pnpm install --frozen-lockfile
-pnpm build
-node dist/cli.mjs tests/fixtures/readme-demo
-```
-
-There is deliberately no `npx scriptspect` quick start yet. The machine-readable
-release state is [docs/readme-status.json](docs/readme-status.json).
 
 <!-- readme-section: demo -->
 ## Before, result, and after
@@ -101,6 +83,27 @@ post-write analysis, and a recovery journal; it never installs dependencies or
 rewrites a lockfile. Regenerate all demo assets with
 `pnpm exec tsx tools/generate-readme-demo.ts`.
 
+<!-- readme-section: evaluate -->
+## Evaluate from source (pre-release)
+
+Requires Node.js 22 or newer and pnpm via Corepack. Clone the repository, check
+out the reviewed commit, install exactly from the lockfile, build, and scan the
+versioned demo fixture. Findings exit `1`; a clean scan exits `0`; invalid input,
+configuration, or I/O exits `2`.
+
+```bash
+git clone https://github.com/Tom409114/scriptspect.git
+cd scriptspect
+git checkout 0898538abef5b054db6a20dc0ffe7fb9bb67e96b
+corepack enable
+pnpm install --frozen-lockfile
+pnpm build
+node dist/cli.mjs tests/fixtures/readme-demo
+```
+
+There is deliberately no `npx scriptspect` quick start yet. The machine-readable
+release state is [docs/readme-status.json](docs/readme-status.json).
+
 <!-- readme-section: cli -->
 ## CLI at a glance
 
@@ -143,7 +146,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Tom409114/scriptspect
-          ref: 13dfcfcec3f50c3dd786a1f9b2a4225391ded0e5
+          ref: 0898538abef5b054db6a20dc0ffe7fb9bb67e96b
           path: .scriptspect
           persist-credentials: false
       - uses: ./.scriptspect
@@ -154,6 +157,16 @@ jobs:
 The Action writes annotations, a job summary, and numeric outputs named
 `exit-code`, `packages`, `scripts`, `errors`, `warnings`, and `advisories` before
 marking a finding run as failed. Its default mode is read-only.
+
+**Real hosted proof — not a mock screenshot.** On `main` at `0898538`, public
+[CI run #33449906358](https://github.com/Tom409114/scriptspect/actions/runs/33449906358)
+consumed `uses: ./` against both clean and broken fixtures. The clean consumer
+reported `1 package · 1 script · 0 errors`; the broken fixture emitted 2 check
+annotations, including `PS010: scripts.clean` on `package.json`.
+
+![Generated card summarizing the verified hosted Action run](docs/assets/demo/action.svg)
+
+[Selectable Action evidence](docs/assets/demo/action.txt) · [Committed source evidence](docs/validation/readme-action-evidence.json) · [Open the hosted job](https://github.com/Tom409114/scriptspect/actions/runs/33449906358/job/99677215357)
 
 <!-- readme-section: config -->
 ## Minimal configuration

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,7 +1,10 @@
 [English](README.md) | [简体中文](README.zh-CN.md)
 
 <p align="center">
-  <img src="docs/assets/brand/hero.svg" width="100%" alt="ScriptSpect 在脚本运行前检查 POSIX shell、Windows cmd 与 PowerShell 的可移植性问题">
+  <picture>
+    <source media="(max-width: 700px)" srcset="docs/assets/brand/hero-mobile.svg">
+    <img src="docs/assets/brand/hero.svg" width="100%" alt="ScriptSpect 在脚本运行前检查 POSIX shell、Windows cmd 与 PowerShell 的可移植性问题">
+  </picture>
 </p>
 
 <p align="center">
@@ -26,23 +29,6 @@ ScriptSpect 会静态检查 npm 风格的 `package.json` scripts，并且不会�
 | 在另一种操作系统真正执行前，找出依赖特定 shell 的命令、operator、expansion、redirection、path 与未声明 executable。 | 每条 finding 都带有稳定 rule ID、package/script path、source span、severity、confidence 与受影响 targets。 | `safe`、`conditional`、`manual` 三类安全级别，避免在无法证明等价时进行“热心”改写。 |
 
 ScriptSpect 使用 target-specific 的结构化 parser，而不是用一组正则表达式扫描 quoted text。它有意不做完整 shell interpreter；finding 仍应由拥有该 script 的项目审查。
-
-<!-- readme-section: evaluate -->
-## 从源码评估（Evaluate from source (pre-release)）
-
-需要 Node.js 22 或更高版本，并通过 Corepack 使用 pnpm。克隆仓库、检出经审阅的 commit、严格按 lockfile 安装、构建，再扫描版本化 demo fixture。存在 finding 时退出 `1`；clean scan 退出 `0`；无效输入、配置或 I/O 退出 `2`。
-
-```bash
-git clone https://github.com/Tom409114/scriptspect.git
-cd scriptspect
-git checkout 13dfcfcec3f50c3dd786a1f9b2a4225391ded0e5
-corepack enable
-pnpm install --frozen-lockfile
-pnpm build
-node dist/cli.mjs tests/fixtures/readme-demo
-```
-
-这里特意还没有 `npx scriptspect` 快速开始。机器可读的 release state 见 [docs/readme-status.json](docs/readme-status.json)。
 
 <!-- readme-section: demo -->
 ## 修复前、分析结果与修复后
@@ -84,6 +70,23 @@ node dist/cli.mjs tests/fixtures/readme-demo
 
 `--fix-dry-run` 只打印 patch 而不写入。`--fix` 使用 staged writes、写后重新分析与 recovery journal；它不会安装依赖或改写 lockfile。使用 `pnpm exec tsx tools/generate-readme-demo.ts` 可重新生成全部 demo assets。
 
+<!-- readme-section: evaluate -->
+## 从源码评估（Evaluate from source (pre-release)）
+
+需要 Node.js 22 或更高版本，并通过 Corepack 使用 pnpm。克隆仓库、检出经审阅的 commit、严格按 lockfile 安装、构建，再扫描版本化 demo fixture。存在 finding 时退出 `1`；clean scan 退出 `0`；无效输入、配置或 I/O 退出 `2`。
+
+```bash
+git clone https://github.com/Tom409114/scriptspect.git
+cd scriptspect
+git checkout 0898538abef5b054db6a20dc0ffe7fb9bb67e96b
+corepack enable
+pnpm install --frozen-lockfile
+pnpm build
+node dist/cli.mjs tests/fixtures/readme-demo
+```
+
+这里特意还没有 `npx scriptspect` 快速开始。机器可读的 release state 见 [docs/readme-status.json](docs/readme-status.json)。
+
 <!-- readme-section: cli -->
 ## CLI 快速参考
 
@@ -121,7 +124,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Tom409114/scriptspect
-          ref: 13dfcfcec3f50c3dd786a1f9b2a4225391ded0e5
+          ref: 0898538abef5b054db6a20dc0ffe7fb9bb67e96b
           path: .scriptspect
           persist-credentials: false
       - uses: ./.scriptspect
@@ -130,6 +133,12 @@ jobs:
 ```
 
 Action 会先写入 annotations、job summary 以及名为 `exit-code`、`packages`、`scripts`、`errors`、`warnings`、`advisories` 的数字 outputs，再把 finding run 标记为失败。默认模式只读。
+
+**真实托管证据——不是模拟截图。** 在 `main` 的 `0898538` 上，公开的 [CI run #33449906358](https://github.com/Tom409114/scriptspect/actions/runs/33449906358) 使用 `uses: ./` 分别消费 clean 与 broken fixture。clean consumer 返回 `1 package · 1 script · 0 errors`；broken fixture 产生 2 条 check annotations，其中包括落在 `package.json` 上的 `PS010: scripts.clean`。
+
+![根据真实托管 Action run 生成的验证卡片](docs/assets/demo/action.svg)
+
+[可选择的 Action 证据文本](docs/assets/demo/action.txt) · [提交进仓库的源证据](docs/validation/readme-action-evidence.json) · [打开托管 job](https://github.com/Tom409114/scriptspect/actions/runs/33449906358/job/99677215357)
 
 <!-- readme-section: config -->
 ## 最小配置

--- a/docs/assets/brand/hero-mobile.svg
+++ b/docs/assets/brand/hero-mobile.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="780" viewBox="0 0 720 780" role="img" aria-labelledby="title desc">
+  <title id="title">ScriptSpect — portable package scripts, checked before they ship</title>
+  <desc id="desc">A compact dark banner for narrow screens, showing ScriptSpect finding two Windows cmd portability problems without running package scripts.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#080d1d"/>
+      <stop offset="0.56" stop-color="#111936"/>
+      <stop offset="1" stop-color="#08251f"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#8b5cf6"/>
+      <stop offset="0.52" stop-color="#38bdf8"/>
+      <stop offset="1" stop-color="#34d399"/>
+    </linearGradient>
+    <radialGradient id="glow">
+      <stop offset="0" stop-color="#38bdf8" stop-opacity="0.25"/>
+      <stop offset="1" stop-color="#38bdf8" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="grid" width="34" height="34" patternUnits="userSpaceOnUse">
+      <path d="M34 0H0V34" fill="none" stroke="#9fb4d8" stroke-opacity="0.055"/>
+    </pattern>
+  </defs>
+
+  <rect width="720" height="780" rx="28" fill="url(#background)"/>
+  <rect width="720" height="780" rx="28" fill="url(#grid)"/>
+  <circle cx="540" cy="235" r="340" fill="url(#glow)"/>
+
+  <g transform="translate(58 58)">
+    <g aria-hidden="true">
+      <rect width="78" height="78" rx="21" fill="#111b38" stroke="#6475a3" stroke-opacity="0.5"/>
+      <path d="M20 23h21c10 0 16 5 16 13 0 8-6 13-16 13H31c-7 0-12 4-12 11 0 7 7 12 16 12h22" fill="none" stroke="url(#accent)" stroke-width="8" stroke-linecap="round"/>
+      <circle cx="58" cy="23" r="5.5" fill="#38bdf8"/>
+      <circle cx="19" cy="72" r="5.5" fill="#34d399"/>
+    </g>
+    <text x="100" y="53" fill="#f8fbff" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="53" font-weight="770" letter-spacing="-1.6">ScriptSpect</text>
+    <rect x="100" y="66" width="385" height="5" rx="2.5" fill="url(#accent)"/>
+    <text x="0" y="137" fill="#d7e2f4" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="29" font-weight="630">Portable scripts. Before they break.</text>
+    <text x="0" y="178" fill="#91a4c4" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="21">Static · target-aware · safe to review</text>
+
+    <g transform="translate(0 211)" font-family="ui-monospace,SFMono-Regular,Consolas,monospace" font-size="18" font-weight="680">
+      <rect width="135" height="43" rx="21.5" fill="#231d4b" stroke="#8b5cf6" stroke-opacity="0.65"/>
+      <text x="24" y="28" fill="#c4b5fd">posix-sh</text>
+      <rect x="150" width="93" height="43" rx="21.5" fill="#123047" stroke="#38bdf8" stroke-opacity="0.65"/>
+      <text x="178" y="28" fill="#7dd3fc">cmd</text>
+      <rect x="258" width="151" height="43" rx="21.5" fill="#10372f" stroke="#34d399" stroke-opacity="0.65"/>
+      <text x="280" y="28" fill="#6ee7b7">powershell</text>
+    </g>
+  </g>
+
+  <g transform="translate(58 365)">
+    <rect width="604" height="337" rx="20" fill="#0b1020" stroke="#8292bd" stroke-opacity="0.3"/>
+    <rect width="604" height="51" rx="20" fill="#151d33"/>
+    <rect y="34" width="604" height="17" fill="#151d33"/>
+    <circle cx="29" cy="25" r="7" fill="#fb7185"/>
+    <circle cx="53" cy="25" r="7" fill="#fbbf24"/>
+    <circle cx="77" cy="25" r="7" fill="#34d399"/>
+    <text x="111" y="32" fill="#8495b5" font-family="ui-monospace,SFMono-Regular,Consolas,monospace" font-size="17">package.json / scripts</text>
+
+    <g font-family="ui-monospace,SFMono-Regular,Consolas,monospace">
+      <text x="31" y="99" fill="#8fa3c7" font-size="19">"build":</text>
+      <text x="132" y="99" fill="#f3f6fb" font-size="18">"NODE_ENV=production …"</text>
+      <path d="M133 111h105" stroke="#a78bfa" stroke-width="3" stroke-linecap="round"/>
+      <text x="376" y="137" fill="#c4b5fd" font-size="20" font-weight="700">PS001 → cmd</text>
+
+      <text x="31" y="178" fill="#8fa3c7" font-size="19">"clean":</text>
+      <text x="132" y="178" fill="#f3f6fb" font-size="18">"rm -rf dist"</text>
+      <path d="M133 190h29" stroke="#38bdf8" stroke-width="3" stroke-linecap="round"/>
+      <text x="376" y="216" fill="#7dd3fc" font-size="20" font-weight="700">PS010 → cmd</text>
+    </g>
+
+    <rect x="28" y="248" width="548" height="58" rx="12" fill="#102a28" stroke="#34d399" stroke-opacity="0.38"/>
+    <path d="M54 276l9 9 17-21" fill="none" stroke="#6ee7b7" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="99" y="286" fill="#a7f3d0" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="21" font-weight="680">analyzed — never executed</text>
+  </g>
+
+  <rect x="58" y="733" width="604" height="4" rx="2" fill="url(#accent)" opacity="0.8"/>
+</svg>

--- a/docs/assets/brand/hero.svg
+++ b/docs/assets/brand/hero.svg
@@ -20,9 +20,6 @@
     <pattern id="grid" width="32" height="32" patternUnits="userSpaceOnUse">
       <path d="M32 0H0V32" fill="none" stroke="#9fb4d8" stroke-opacity="0.055"/>
     </pattern>
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="18" flood-color="#000" flood-opacity="0.34"/>
-    </filter>
   </defs>
 
   <rect width="1200" height="360" rx="24" fill="url(#background)"/>
@@ -51,7 +48,7 @@
     </g>
   </g>
 
-  <g transform="translate(706 63)" filter="url(#shadow)">
+  <g transform="translate(706 63)">
     <rect width="422" height="235" rx="16" fill="#0b1020" stroke="#8292bd" stroke-opacity="0.28"/>
     <rect width="422" height="38" rx="16" fill="#151d33"/>
     <rect y="25" width="422" height="13" fill="#151d33"/>

--- a/docs/assets/demo/action.svg
+++ b/docs/assets/demo/action.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="480" viewBox="0 0 1100 480" role="img" aria-labelledby="title desc" data-run-id="33449906358">
+  <title id="title">Hosted Action evidence</title>
+  <desc id="desc">Public CI run 33449906358 passed at source commit 0898538a. A clean consumer returned zero errors, while the broken fixture produced 2 annotations including PS010: scripts.clean.</desc>
+  <defs>
+    <linearGradient id="action-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#090d1a"/>
+      <stop offset="0.55" stop-color="#111a35"/>
+      <stop offset="1" stop-color="#09251f"/>
+    </linearGradient>
+    <linearGradient id="action-line" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#8b5cf6"/>
+      <stop offset="0.52" stop-color="#38bdf8"/>
+      <stop offset="1" stop-color="#34d399"/>
+    </linearGradient>
+  </defs>
+  <style>
+    .sans { font-family: Inter,Segoe UI,Arial,sans-serif; }
+    .mono { font-family: ui-monospace,SFMono-Regular,Consolas,monospace; }
+    .muted { fill: #91a4c4; }
+    .label { fill: #b8c7df; font-size: 15px; font-weight: 650; letter-spacing: .7px; }
+    .metric { fill: #f5f8ff; font-size: 28px; font-weight: 760; }
+  </style>
+  <rect width="1100" height="480" rx="22" fill="url(#action-bg)"/>
+  <rect x="1" y="1" width="1098" height="478" rx="21" fill="none" stroke="#7c8db5" stroke-opacity="0.28"/>
+  <rect x="52" y="46" width="9" height="42" rx="4.5" fill="url(#action-line)"/>
+  <text x="82" y="70" class="sans" fill="#f8fbff" font-size="30" font-weight="770">Hosted Action evidence</text>
+  <text x="82" y="94" class="mono muted" font-size="14">main @ 0898538a · CI run #33449906358</text>
+  <rect x="866" y="50" width="182" height="38" rx="19" fill="#10372f" stroke="#34d399" stroke-opacity="0.65"/>
+  <circle cx="890" cy="69" r="7" fill="#34d399"/>
+  <text x="908" y="75" class="sans" fill="#a7f3d0" font-size="16" font-weight="720">VERIFIED · PASS</text>
+
+  <g transform="translate(52 132)">
+    <rect width="306" height="150" rx="16" fill="#10182d" stroke="#6475a3" stroke-opacity="0.35"/>
+    <text x="24" y="34" class="sans label">CLEAN CONSUMER</text>
+    <text x="24" y="82" class="sans metric">0 errors</text>
+    <text x="24" y="112" class="mono muted" font-size="15">1 package · 1 script</text>
+    <path d="M25 130l7 7 13-16" fill="none" stroke="#34d399" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="56" y="139" class="sans" fill="#a7f3d0" font-size="15">exit code 0</text>
+  </g>
+
+  <g transform="translate(397 132)">
+    <rect width="306" height="150" rx="16" fill="#10182d" stroke="#6475a3" stroke-opacity="0.35"/>
+    <text x="24" y="34" class="sans label">BROKEN FIXTURE</text>
+    <text x="24" y="82" class="sans metric">2 annotations</text>
+    <text x="24" y="112" class="mono" fill="#ffb4ad" font-size="16" font-weight="700">PS010: scripts.clean</text>
+    <text x="24" y="136" class="mono muted" font-size="14">package.json · target cmd</text>
+  </g>
+
+  <g transform="translate(742 132)">
+    <rect width="306" height="150" rx="16" fill="#10182d" stroke="#6475a3" stroke-opacity="0.35"/>
+    <text x="24" y="34" class="sans label">ACTION CONTRACT</text>
+    <text x="24" y="75" class="sans" fill="#f5f8ff" font-size="20" font-weight="720">Annotations + summary</text>
+    <text x="24" y="105" class="sans" fill="#f5f8ff" font-size="20" font-weight="720">Numeric outputs</text>
+    <text x="24" y="134" class="mono muted" font-size="14">read-only by default</text>
+  </g>
+
+  <g transform="translate(52 322)">
+    <rect width="996" height="104" rx="14" fill="#0b1223" stroke="#ef6f6c" stroke-opacity="0.34"/>
+    <rect width="7" height="104" rx="3.5" fill="#ff7b72"/>
+    <text x="28" y="30" class="mono" fill="#ffb4ad" font-size="15" font-weight="720">PS010: scripts.clean</text>
+    <text x="28" y="58" class="mono" fill="#d7e2f4" font-size="15">`rm -rf` is not available in native Windows npm scripts · affected: cmd · scripts.clean</text>
+    <text x="28" y="84" class="sans muted" font-size="14">Generated from committed public run evidence · package scripts were never executed</text>
+  </g>
+</svg>

--- a/docs/assets/demo/action.txt
+++ b/docs/assets/demo/action.txt
@@ -1,0 +1,9 @@
+ScriptSpect hosted Action evidence
+workflow run: 33449906358 (success)
+workflow URL: https://github.com/Tom409114/scriptspect/actions/runs/33449906358
+source commit: 0898538abef5b054db6a20dc0ffe7fb9bb67e96b
+clean consumer: exit 0 · 1 package · 1 script · 0 errors
+broken fixture: 2 annotations
+- Action failure contract — .github: scriptspect action failed
+- PS010: scripts.clean — package.json: `rm -rf` is not available in native Windows npm scripts · affected: cmd · scripts.clean
+job summary SHA-256: 6f404488da1babb4ba885e873c5187e4e1c5179a2c868bc5324a2e3b8c71c404

--- a/docs/readme-status.json
+++ b/docs/readme-status.json
@@ -3,7 +3,7 @@
   "releaseState": "pre-release",
   "packageName": "scriptspect",
   "packageVersion": "0.0.0",
-  "sourceCommit": "13dfcfcec3f50c3dd786a1f9b2a4225391ded0e5",
+  "sourceCommit": "0898538abef5b054db6a20dc0ffe7fb9bb67e96b",
   "nodeMajor": 22,
   "repository": "https://github.com/Tom409114/scriptspect"
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -38,7 +38,7 @@ publication, tag-actor, and external-evidence gates.
 | Gate | Status | Evidence |
 | --- | --- | --- |
 | Precision | ⚠️ promising, sample incomplete | 62/62 verified true positives in a stratified 14-rule sample; the ≥100 review gate is not met |
-| Real-problem density | ✅ pass | 534 findings across 68 repos and 14 rule categories; verified sample spans 35 repos |
+| Real-problem density | ⚠️ historical signal | Superseded root-only run found 534 findings across 68 repos; the workspace-full rerun and review are still pending |
 | Competitive edge | ⏳ pending | category coverage is promising, but no shared-fixture head-to-head has been run |
 | External interest | ⏳ not yet met | 0 external issues as of 2026-08-31 (pre-release) |
 | Onboarding | ⏳ pending | requires the v0.1 npm publish |

--- a/docs/validation/readme-action-evidence.json
+++ b/docs/validation/readme-action-evidence.json
@@ -28,7 +28,8 @@
       "level": "failure",
       "path": ".github",
       "line": 6,
-      "title": "Action failure contract",
+      "title": "",
+      "displayTitle": "Action failure contract",
       "message": "scriptspect action failed"
     },
     {

--- a/docs/validation/readme-action-evidence.json
+++ b/docs/validation/readme-action-evidence.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": 1,
+  "capturedAt": "2026-08-31T23:17:14Z",
+  "sourceCommit": "0898538abef5b054db6a20dc0ffe7fb9bb67e96b",
+  "workflowRun": {
+    "id": 33449906358,
+    "name": "CI",
+    "url": "https://github.com/Tom409114/scriptspect/actions/runs/33449906358",
+    "conclusion": "success"
+  },
+  "checkRun": {
+    "id": 99677215357,
+    "name": "Bundled Action consumer",
+    "url": "https://github.com/Tom409114/scriptspect/actions/runs/33449906358/job/99677215357",
+    "annotationCount": 2,
+    "summarySha256": "6f404488da1babb4ba885e873c5187e4e1c5179a2c868bc5324a2e3b8c71c404"
+  },
+  "cleanConsumer": {
+    "exitCode": 0,
+    "packages": 1,
+    "scripts": 1,
+    "errors": 0,
+    "warnings": 0,
+    "advisories": 0
+  },
+  "annotations": [
+    {
+      "level": "failure",
+      "path": ".github",
+      "line": 6,
+      "title": "Action failure contract",
+      "message": "scriptspect action failed"
+    },
+    {
+      "level": "failure",
+      "path": "package.json",
+      "line": 0,
+      "title": "PS010: scripts.clean",
+      "message": "`rm -rf` is not available in native Windows npm scripts · affected%3A cmd · scripts.clean"
+    }
+  ]
+}

--- a/tests/docs/public-claims.test.ts
+++ b/tests/docs/public-claims.test.ts
@@ -23,6 +23,16 @@ describe('public project claims', () => {
     expect(report).toContain('Not a scripts-doctor head-to-head');
   });
 
+  it('does not promote superseded corpus density evidence to a passed release gate', () => {
+    const roadmap = read('docs/roadmap.md');
+    const report = read('docs/validation/corpus-2026-08.md');
+
+    expect(report).toContain('Superseded as release-gate evidence');
+    expect(report).toMatch(/Real-problem density[^\n]+HISTORICAL SIGNAL/iu);
+    expect(roadmap).not.toMatch(/Real-problem density[^\n]+✅ pass/iu);
+    expect(roadmap).toMatch(/Real-problem density[^\n]+historical signal/iu);
+  });
+
   it('documents the configured failure universe instead of a confidence shortcut', () => {
     const english = read('README.md');
     const chinese = read('README.zh-CN.md');

--- a/tests/docs/readme-homepage.test.ts
+++ b/tests/docs/readme-homepage.test.ts
@@ -73,7 +73,7 @@ describe('bilingual pre-release homepage', () => {
       workflowRun: { id: number; url: string; conclusion: string };
       checkRun: { id: number; annotationCount: number };
       cleanConsumer: { exitCode: number; packages: number; scripts: number; errors: number };
-      annotations: Array<{ title: string; message: string }>;
+      annotations: Array<{ title: string; displayTitle?: string; message: string }>;
     };
 
     expect(evidence.sourceCommit).toBe('0898538abef5b054db6a20dc0ffe7fb9bb67e96b');
@@ -95,6 +95,13 @@ describe('bilingual pre-release homepage', () => {
         title: 'PS010: scripts.clean',
         message:
           '`rm -rf` is not available in native Windows npm scripts · affected%3A cmd · scripts.clean',
+      }),
+    );
+    expect(evidence.annotations).toContainEqual(
+      expect.objectContaining({
+        title: '',
+        displayTitle: 'Action failure contract',
+        message: 'scriptspect action failed',
       }),
     );
 

--- a/tests/docs/readme-homepage.test.ts
+++ b/tests/docs/readme-homepage.test.ts
@@ -16,21 +16,28 @@ const fencedBlocks = (markdown: string): string[] =>
   [...markdown.matchAll(/```[^\n]*\n([\s\S]*?)```/g)].map((match) => match[1] ?? '');
 
 describe('bilingual pre-release homepage', () => {
-  it('uses one accessible, self-contained brand hero and only truthful badges', () => {
+  it('uses responsive, accessible, self-contained brand heroes and only truthful badges', () => {
     const english = read('README.md');
     const chinese = read('README.zh-CN.md');
     const hero = read('docs/assets/brand/hero.svg');
+    const mobileHero = read('docs/assets/brand/hero-mobile.svg');
 
     for (const homepage of [english, chinese]) {
       expect(homepage).toContain('docs/assets/brand/hero.svg');
+      expect(homepage).toContain('<picture>');
+      expect(homepage).toContain('media="(max-width: 700px)"');
+      expect(homepage).toContain('docs/assets/brand/hero-mobile.svg');
       expect(homepage).toContain('actions/workflows/ci.yml/badge.svg?branch=main');
       expect(homepage).toContain('license-MIT');
       expect(homepage).not.toMatch(/badge[^\n]*(?:stars|downloads|precision|production)/iu);
     }
-    expect(hero).toMatch(/<svg[^>]+role="img"[^>]+aria-labelledby=/u);
-    expect(hero).toContain('<title id="title">');
-    expect(hero).toContain('<desc id="desc">');
-    expect(hero).not.toMatch(/<script|(?:href|src)=["']https?:\/\//iu);
+    for (const artwork of [hero, mobileHero]) {
+      expect(artwork).toMatch(/<svg[^>]+role="img"[^>]+aria-labelledby=/u);
+      expect(artwork).toContain('<title id="title">');
+      expect(artwork).toContain('<desc id="desc">');
+      expect(artwork).not.toMatch(/<script|(?:href|src)=["']https?:\/\//iu);
+      expect(artwork).not.toContain('<filter');
+    }
   });
 
   it('does not present an unpublished package or Action release as usable', () => {
@@ -42,6 +49,7 @@ describe('bilingual pre-release homepage', () => {
     };
 
     expect(status.releaseState).toBe('pre-release');
+    expect(status.sourceCommit).toBe('0898538abef5b054db6a20dc0ffe7fb9bb67e96b');
     for (const homepage of [english, chinese]) {
       expect(homepage).toContain('Evaluate from source (pre-release)');
       expect(fencedBlocks(homepage).some((block) => /\bnpx\s+scriptspect\b/.test(block))).toBe(
@@ -54,6 +62,52 @@ describe('bilingual pre-release homepage', () => {
       expect(homepage).not.toMatch(/production[- ]ready/i);
       expect(homepage).toContain(`git checkout ${status.sourceCommit}`);
       expect(homepage).toContain(`ref: ${status.sourceCommit}`);
+    }
+  });
+
+  it('leads with the executable demo and links real hosted Action evidence', () => {
+    const english = read('README.md');
+    const chinese = read('README.zh-CN.md');
+    const evidence = JSON.parse(read('docs/validation/readme-action-evidence.json')) as {
+      sourceCommit: string;
+      workflowRun: { id: number; url: string; conclusion: string };
+      checkRun: { id: number; annotationCount: number };
+      cleanConsumer: { exitCode: number; packages: number; scripts: number; errors: number };
+      annotations: Array<{ title: string; message: string }>;
+    };
+
+    expect(evidence.sourceCommit).toBe('0898538abef5b054db6a20dc0ffe7fb9bb67e96b');
+    expect(evidence.workflowRun).toEqual(
+      expect.objectContaining({
+        id: 33449906358,
+        conclusion: 'success',
+        url: 'https://github.com/Tom409114/scriptspect/actions/runs/33449906358',
+      }),
+    );
+    expect(evidence.checkRun).toEqual(
+      expect.objectContaining({ id: 99677215357, annotationCount: 2 }),
+    );
+    expect(evidence.cleanConsumer).toEqual(
+      expect.objectContaining({ exitCode: 0, packages: 1, scripts: 1, errors: 0 }),
+    );
+    expect(evidence.annotations).toContainEqual(
+      expect.objectContaining({
+        title: 'PS010: scripts.clean',
+        message:
+          '`rm -rf` is not available in native Windows npm scripts · affected%3A cmd · scripts.clean',
+      }),
+    );
+
+    for (const homepage of [english, chinese]) {
+      expect(homepage.indexOf('<!-- readme-section: demo -->')).toBeLessThan(
+        homepage.indexOf('<!-- readme-section: evaluate -->'),
+      );
+      expect(homepage).toContain('docs/assets/demo/action.svg');
+      expect(homepage).toContain('docs/assets/demo/action.txt');
+      expect(homepage).toContain('docs/validation/readme-action-evidence.json');
+      expect(homepage).toContain(evidence.workflowRun.url);
+      expect(homepage).toContain('33449906358');
+      expect(homepage).toContain('0898538');
     }
   });
 
@@ -78,6 +132,8 @@ describe('README demo artifacts', () => {
     'docs/assets/demo/fix.patch',
     'docs/assets/demo/package.after.json',
     'docs/assets/demo/terminal.svg',
+    'docs/assets/demo/action.txt',
+    'docs/assets/demo/action.svg',
   ];
 
   it('are deterministically generated from one fixture with accessible, ANSI-free output', () => {
@@ -109,6 +165,16 @@ describe('README demo artifacts', () => {
     );
     expect(renderedColumnCounts.length).toBeGreaterThan(terminal.split('\n').length);
     expect(Math.max(...renderedColumnCounts)).toBeLessThanOrEqual(104);
+    const actionText = read('docs/assets/demo/action.txt');
+    expect(actionText).toContain('workflow run: 33449906358 (success)');
+    expect(actionText).toContain('source commit: 0898538abef5b054db6a20dc0ffe7fb9bb67e96b');
+    expect(actionText).toContain('broken fixture: 2 annotations');
+    expect(actionText).toContain('PS010: scripts.clean');
+    const actionSvg = read('docs/assets/demo/action.svg');
+    expect(actionSvg).toMatch(/<svg[^>]+role="img"[^>]+aria-labelledby=/);
+    expect(actionSvg).toContain('Hosted Action evidence');
+    expect(actionSvg).toContain('data-run-id="33449906358"');
+    expect(actionSvg).not.toMatch(/<script|(?:href|src)=["']https?:\/\//iu);
     const patch = read('docs/assets/demo/fix.patch');
     expect(patch).toContain('--- a/package.json');
     expect(patch).not.toContain('Scanned ');

--- a/tests/workflows/ci-policy.test.ts
+++ b/tests/workflows/ci-policy.test.ts
@@ -199,6 +199,8 @@ describe('reproducible CI', () => {
     expect(generatedRun).toContain('docs/readme-status.json');
     expect(generatedRun).toContain('git cat-file -e');
     expect(generatedRun).toContain('git merge-base --is-ancestor');
+    expect(generatedRun).toContain('git diff --quiet "$STATUS_COMMIT" HEAD --');
+    expect(generatedRun).not.toContain('git diff-tree');
     expect(generatedRun).toContain('git diff --exit-code');
 
     const generatedCheckout = (ci.jobs?.generated?.steps ?? []).find((step) =>

--- a/tests/workflows/ci-policy.test.ts
+++ b/tests/workflows/ci-policy.test.ts
@@ -199,6 +199,9 @@ describe('reproducible CI', () => {
     expect(generatedRun).toContain('docs/readme-status.json');
     expect(generatedRun).toContain('git cat-file -e');
     expect(generatedRun).toContain('git merge-base --is-ancestor');
+    expect(generatedRun).toContain('SOURCE_BASE');
+    expect(generatedRun).toContain('if ! git diff --quiet "$SOURCE_BASE" HEAD --');
+    expect(generatedRun).toContain('docs/validation/readme-action-evidence.json');
     expect(generatedRun).toContain('git diff --quiet "$STATUS_COMMIT" HEAD --');
     expect(generatedRun).not.toContain('git diff-tree');
     expect(generatedRun).toContain('git diff --exit-code');

--- a/tests/workflows/ci-policy.test.ts
+++ b/tests/workflows/ci-policy.test.ts
@@ -203,6 +203,22 @@ describe('reproducible CI', () => {
     expect(generatedRun).not.toContain('git diff-tree');
     expect(generatedRun).toContain('git diff --exit-code');
 
+    const statusGenerator = readFileSync(join(root, 'tools/generate-readme-status.ts'), 'utf8');
+    for (const sourceInput of [
+      'src',
+      'dist',
+      'schema',
+      'package.json',
+      'pnpm-lock.yaml',
+      'pnpm-workspace.yaml',
+      'action.yml',
+      'tsconfig.json',
+      'tsup.config.ts',
+    ]) {
+      expect(generatedRun).toContain(sourceInput);
+      expect(statusGenerator).toContain(`'${sourceInput}'`);
+    }
+
     const generatedCheckout = (ci.jobs?.generated?.steps ?? []).find((step) =>
       step.uses?.startsWith('actions/checkout@'),
     );

--- a/tests/workflows/ci-policy.test.ts
+++ b/tests/workflows/ci-policy.test.ts
@@ -200,7 +200,20 @@ describe('reproducible CI', () => {
     expect(generatedRun).toContain('git cat-file -e');
     expect(generatedRun).toContain('git merge-base --is-ancestor');
     expect(generatedRun).toContain('SOURCE_BASE');
-    expect(generatedRun).toContain('if ! git diff --quiet "$SOURCE_BASE" HEAD --');
+    expect(generatedRun).toContain('set -o pipefail');
+    expect(generatedRun).toContain('SOURCE_DIFF=$?');
+    expect(generatedRun).toContain('case "$SOURCE_DIFF" in');
+    expect(generatedRun).not.toContain('if ! git diff --quiet "$SOURCE_BASE" HEAD --');
+    expect(generatedRun).toContain('git archive "$STATUS_COMMIT"');
+    for (const pinnedAsset of [
+      'package.before.json',
+      'terminal.txt',
+      'fix.patch',
+      'package.after.json',
+      'terminal.svg',
+    ]) {
+      expect(generatedRun).toContain(pinnedAsset);
+    }
     expect(generatedRun).toContain('docs/validation/readme-action-evidence.json');
     expect(generatedRun).toContain('git diff --quiet "$STATUS_COMMIT" HEAD --');
     expect(generatedRun).not.toContain('git diff-tree');

--- a/tools/generate-readme-demo.ts
+++ b/tools/generate-readme-demo.ts
@@ -31,6 +31,7 @@ type ActionEvidence = {
     path: string;
     line: number;
     title: string;
+    displayTitle?: string;
     message: string;
   }>;
 };
@@ -120,7 +121,7 @@ ${rows}
 function actionEvidenceText(evidence: ActionEvidence): string {
   const annotations = evidence.annotations.map(
     (annotation) =>
-      `- ${annotation.title} — ${annotation.path}: ${annotation.message.replaceAll('%3A', ':')}`,
+      `- ${annotation.title || annotation.displayTitle || 'Action annotation'} — ${annotation.path}: ${annotation.message.replaceAll('%3A', ':')}`,
   );
   return [
     'ScriptSpect hosted Action evidence',

--- a/tools/generate-readme-demo.ts
+++ b/tools/generate-readme-demo.ts
@@ -5,8 +5,36 @@ import { fileURLToPath } from 'node:url';
 
 const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const fixture = resolve(root, 'tests/fixtures/readme-demo/package.json');
+const actionEvidenceFile = resolve(root, 'docs/validation/readme-action-evidence.json');
 const outputDir = resolve(root, 'docs/assets/demo');
 const before = readFileSync(fixture, 'utf8');
+type ActionEvidence = {
+  sourceCommit: string;
+  workflowRun: { id: number; name: string; url: string; conclusion: string };
+  checkRun: {
+    id: number;
+    name: string;
+    url: string;
+    annotationCount: number;
+    summarySha256: string;
+  };
+  cleanConsumer: {
+    exitCode: number;
+    packages: number;
+    scripts: number;
+    errors: number;
+    warnings: number;
+    advisories: number;
+  };
+  annotations: Array<{
+    level: string;
+    path: string;
+    line: number;
+    title: string;
+    message: string;
+  }>;
+};
+const actionEvidence = JSON.parse(readFileSync(actionEvidenceFile, 'utf8')) as ActionEvidence;
 // runCli normally receives this build-time constant from tsup/vitest. The
 // generator imports the source directly so it supplies the same package value.
 Reflect.set(globalThis, '__PKG_VERSION__', '0.0.0');
@@ -89,6 +117,99 @@ ${rows}
 `;
 }
 
+function actionEvidenceText(evidence: ActionEvidence): string {
+  const annotations = evidence.annotations.map(
+    (annotation) =>
+      `- ${annotation.title} — ${annotation.path}: ${annotation.message.replaceAll('%3A', ':')}`,
+  );
+  return [
+    'ScriptSpect hosted Action evidence',
+    `workflow run: ${evidence.workflowRun.id} (${evidence.workflowRun.conclusion})`,
+    `workflow URL: ${evidence.workflowRun.url}`,
+    `source commit: ${evidence.sourceCommit}`,
+    `clean consumer: exit ${evidence.cleanConsumer.exitCode} · ${evidence.cleanConsumer.packages} package · ${evidence.cleanConsumer.scripts} script · ${evidence.cleanConsumer.errors} errors`,
+    `broken fixture: ${evidence.checkRun.annotationCount} annotations`,
+    ...annotations,
+    `job summary SHA-256: ${evidence.checkRun.summarySha256}`,
+  ].join('\n');
+}
+
+function actionEvidenceSvg(evidence: ActionEvidence): string {
+  const shortSha = evidence.sourceCommit.slice(0, 8);
+  const finding =
+    evidence.annotations.find((annotation) => /^PS\d{3}:/u.test(annotation.title)) ??
+    evidence.annotations[0];
+  if (finding === undefined) throw new Error('README Action evidence needs an annotation');
+  const findingMessage = finding.message.replaceAll('%3A', ':');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="480" viewBox="0 0 1100 480" role="img" aria-labelledby="title desc" data-run-id="${evidence.workflowRun.id}">
+  <title id="title">Hosted Action evidence</title>
+  <desc id="desc">Public CI run ${evidence.workflowRun.id} passed at source commit ${shortSha}. A clean consumer returned zero errors, while the broken fixture produced ${evidence.checkRun.annotationCount} annotations including ${xml(finding.title)}.</desc>
+  <defs>
+    <linearGradient id="action-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#090d1a"/>
+      <stop offset="0.55" stop-color="#111a35"/>
+      <stop offset="1" stop-color="#09251f"/>
+    </linearGradient>
+    <linearGradient id="action-line" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#8b5cf6"/>
+      <stop offset="0.52" stop-color="#38bdf8"/>
+      <stop offset="1" stop-color="#34d399"/>
+    </linearGradient>
+  </defs>
+  <style>
+    .sans { font-family: Inter,Segoe UI,Arial,sans-serif; }
+    .mono { font-family: ui-monospace,SFMono-Regular,Consolas,monospace; }
+    .muted { fill: #91a4c4; }
+    .label { fill: #b8c7df; font-size: 15px; font-weight: 650; letter-spacing: .7px; }
+    .metric { fill: #f5f8ff; font-size: 28px; font-weight: 760; }
+  </style>
+  <rect width="1100" height="480" rx="22" fill="url(#action-bg)"/>
+  <rect x="1" y="1" width="1098" height="478" rx="21" fill="none" stroke="#7c8db5" stroke-opacity="0.28"/>
+  <rect x="52" y="46" width="9" height="42" rx="4.5" fill="url(#action-line)"/>
+  <text x="82" y="70" class="sans" fill="#f8fbff" font-size="30" font-weight="770">Hosted Action evidence</text>
+  <text x="82" y="94" class="mono muted" font-size="14">main @ ${shortSha} · CI run #${evidence.workflowRun.id}</text>
+  <rect x="866" y="50" width="182" height="38" rx="19" fill="#10372f" stroke="#34d399" stroke-opacity="0.65"/>
+  <circle cx="890" cy="69" r="7" fill="#34d399"/>
+  <text x="908" y="75" class="sans" fill="#a7f3d0" font-size="16" font-weight="720">VERIFIED · PASS</text>
+
+  <g transform="translate(52 132)">
+    <rect width="306" height="150" rx="16" fill="#10182d" stroke="#6475a3" stroke-opacity="0.35"/>
+    <text x="24" y="34" class="sans label">CLEAN CONSUMER</text>
+    <text x="24" y="82" class="sans metric">${evidence.cleanConsumer.errors} errors</text>
+    <text x="24" y="112" class="mono muted" font-size="15">${evidence.cleanConsumer.packages} package · ${evidence.cleanConsumer.scripts} script</text>
+    <path d="M25 130l7 7 13-16" fill="none" stroke="#34d399" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="56" y="139" class="sans" fill="#a7f3d0" font-size="15">exit code ${evidence.cleanConsumer.exitCode}</text>
+  </g>
+
+  <g transform="translate(397 132)">
+    <rect width="306" height="150" rx="16" fill="#10182d" stroke="#6475a3" stroke-opacity="0.35"/>
+    <text x="24" y="34" class="sans label">BROKEN FIXTURE</text>
+    <text x="24" y="82" class="sans metric">${evidence.checkRun.annotationCount} annotations</text>
+    <text x="24" y="112" class="mono" fill="#ffb4ad" font-size="16" font-weight="700">${xml(finding.title)}</text>
+    <text x="24" y="136" class="mono muted" font-size="14">${xml(finding.path)} · target cmd</text>
+  </g>
+
+  <g transform="translate(742 132)">
+    <rect width="306" height="150" rx="16" fill="#10182d" stroke="#6475a3" stroke-opacity="0.35"/>
+    <text x="24" y="34" class="sans label">ACTION CONTRACT</text>
+    <text x="24" y="75" class="sans" fill="#f5f8ff" font-size="20" font-weight="720">Annotations + summary</text>
+    <text x="24" y="105" class="sans" fill="#f5f8ff" font-size="20" font-weight="720">Numeric outputs</text>
+    <text x="24" y="134" class="mono muted" font-size="14">read-only by default</text>
+  </g>
+
+  <g transform="translate(52 322)">
+    <rect width="996" height="104" rx="14" fill="#0b1223" stroke="#ef6f6c" stroke-opacity="0.34"/>
+    <rect width="7" height="104" rx="3.5" fill="#ff7b72"/>
+    <text x="28" y="30" class="mono" fill="#ffb4ad" font-size="15" font-weight="720">${xml(finding.title)}</text>
+    <text x="28" y="58" class="mono" fill="#d7e2f4" font-size="15">${xml(findingMessage)}</text>
+    <text x="28" y="84" class="sans muted" font-size="14">Generated from committed public run evidence · package scripts were never executed</text>
+  </g>
+</svg>
+`;
+}
+
 mkdirSync(outputDir, { recursive: true });
 const dir = mkdtempSync(resolve(tmpdir(), 'scriptspect-readme-demo-'));
 try {
@@ -130,6 +251,9 @@ try {
     readFileSync(resolve(dir, 'package.json'), 'utf8'),
   );
   writeFileSync(resolve(outputDir, 'terminal.svg'), terminalSvg(terminal));
+  const hostedAction = actionEvidenceText(actionEvidence);
+  writeFileSync(resolve(outputDir, 'action.txt'), `${hostedAction}\n`);
+  writeFileSync(resolve(outputDir, 'action.svg'), actionEvidenceSvg(actionEvidence));
 } finally {
   rmSync(dir, { recursive: true, force: true });
 }

--- a/tools/generate-readme-status.ts
+++ b/tools/generate-readme-status.ts
@@ -17,24 +17,28 @@ const sourceCommit = execFileSync('git', ['rev-parse', `${requestedCommit}^{comm
   encoding: 'utf8',
 }).trim();
 execFileSync('git', ['merge-base', '--is-ancestor', sourceCommit, 'HEAD'], { cwd: root });
-const sourceFiles = execFileSync(
-  'git',
-  [
-    'diff-tree',
-    '--root',
-    '--no-commit-id',
-    '--name-only',
-    '-r',
-    sourceCommit,
-    '--',
-    'src',
-    'package.json',
-    'action.yml',
-  ],
-  { cwd: root, encoding: 'utf8' },
-);
-if (!/^(src\/|package\.json$|action\.yml$)/m.test(sourceFiles)) {
-  throw new Error('source commit must contain a runtime, package, or Action change');
+try {
+  execFileSync(
+    'git',
+    [
+      'diff',
+      '--quiet',
+      sourceCommit,
+      'HEAD',
+      '--',
+      'src',
+      'dist',
+      'schema',
+      'package.json',
+      'pnpm-lock.yaml',
+      'action.yml',
+      'tsconfig.json',
+      'tsup.config.ts',
+    ],
+    { cwd: root },
+  );
+} catch {
+  throw new Error('source commit must match HEAD for runtime, package, and Action files');
 }
 const releaseState = pkg.version === '0.0.0' ? 'pre-release' : 'published';
 

--- a/tools/generate-readme-status.ts
+++ b/tools/generate-readme-status.ts
@@ -31,6 +31,7 @@ try {
       'schema',
       'package.json',
       'pnpm-lock.yaml',
+      'pnpm-workspace.yaml',
       'action.yml',
       'tsconfig.json',
       'tsup.config.ts',


### PR DESCRIPTION
## What changed

- moves the executable before/result/after demo ahead of setup instructions in both English and Simplified Chinese
- adds a responsive mobile hero and removes SVG filters that caused content to disappear in some renderers
- pins source evaluation and the bundled Action example to safe, hosted-CI-verified commit 0898538abef5b054db6a20dc0ffe7fb9bb67e96b
- adds deterministic hosted Action evidence generated from public CI run 33449906358 and check run 99677215357
- records raw API evidence separately from human-readable display labels
- replaces the old source-commit heuristic with exact runtime/build-input tree parity, including pnpm-workspace.yaml
- corrects the superseded corpus density gate from pass to historical signal

## Verification

- pnpm test: 55 files, 603 passed, 6 skipped
- pnpm typecheck
- pnpm lint: 167 files clean
- README parity check passed
- demo and Action assets regenerate with zero diff
- independent code review: no remaining Critical or Important findings

## Release safety

This remains an honest pre-release source evaluation. It does not claim that npm, a public Action tag, or v0.1 artifacts exist.