### PR TITLE
fix(ci): load release gate from event-bound main

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -20,7 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/tests/release/release-contract.test.ts
+++ b/tests/release/release-contract.test.ts
@@ -403,6 +403,12 @@ describe('release coordinator trust and recovery', () => {
     });
     expect(readiness.permissions).toEqual({ contents: 'read' });
     expect(readiness.jobs).toHaveProperty('release-pr-readiness');
+    const readinessCheckout = readiness.jobs?.['release-pr-readiness']?.steps?.find((step) =>
+      step.uses?.startsWith('actions/checkout@'),
+    );
+    expect(readinessCheckout).toBeDefined();
+    expect(readinessCheckout?.with ?? {}).not.toHaveProperty('ref');
+    expect(readinessCheckout?.with).toMatchObject({ 'persist-credentials': false });
 
     const gate = jobSource('release-readiness.yml', 'release-pr-readiness');
     for (const predicate of [
@@ -412,7 +418,7 @@ describe('release coordinator trust and recovery', () => {
       expect(gate).toContain(predicate);
     }
     const readinessSource = source('release-readiness.yml');
-    expect(readinessSource).toContain('github.event.pull_request.base.sha');
+    expect(readinessSource).not.toContain('github.event.pull_request.base.sha');
     expect(readinessSource).not.toContain('github.event.pull_request.head.sha');
     expect(readinessSource).not.toContain('github.event.pull_request.head.ref');
     expect(readinessSource).toContain('node-version: 22');

--- a/tests/workflows/ci-policy.test.ts
+++ b/tests/workflows/ci-policy.test.ts
@@ -119,8 +119,14 @@ describe('pull-request trust boundary', () => {
     expect(targetWorkflows).toEqual(['release-readiness.yml']);
     const trustedGate = workflow('release-readiness.yml');
     expect(trustedGate.permissions).toEqual({ contents: 'read' });
+    const trustedCheckout = allSteps(trustedGate).find((step) =>
+      step.uses?.startsWith('actions/checkout@'),
+    );
+    expect(trustedCheckout).toBeDefined();
+    expect(trustedCheckout?.with ?? {}).not.toHaveProperty('ref');
+    expect(trustedCheckout?.with).toMatchObject({ 'persist-credentials': false });
     const trustedSource = workflowSource('release-readiness.yml');
-    expect(trustedSource).toContain('github.event.pull_request.base.sha');
+    expect(trustedSource).not.toContain('github.event.pull_request.base.sha');
     expect(trustedSource).not.toContain('github.event.pull_request.head.sha');
     expect(trustedSource).not.toContain('github.event.pull_request.head.ref');
     expect(trustedSource).not.toContain('secrets.');


### PR DESCRIPTION
## Why

An existing release PR can retain an older `pull_request.base.sha`. The first live readiness run therefore checked out a base commit that predated the gate script and failed with `MODULE_NOT_FOUND` instead of evaluating publication controls.

## Fix

- let `pull_request_target` and pinned checkout v7 use the event-bound trusted default-branch ref and SHA
- never override checkout with PR base/head refs
- structurally enforce no checkout `ref` and `persist-credentials: false`

## Verification

- 56 test files: 627 passed, 6 skipped
- TypeScript typecheck
- Biome (170 files)
- actionlint 1.7.12
- independent review: Ready

After merge, PR #66 will be refreshed and must fail for the expected publication-readiness switches, not for a missing module.