### PR TITLE
feat: upgrade homepage and harden release evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
     name: Generated files are current
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      checks: read
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -51,12 +54,14 @@ jobs:
           pnpm install --frozen-lockfile
       - name: Regenerate schemas, rule docs, and bilingual demo assets
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           SOURCE_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
         run: |
           set -o pipefail
           pnpm exec tsx tools/generate-schemas.ts
           pnpm docs:rules
           pnpm exec tsx tools/generate-readme-demo.ts
+          pnpm exec tsx tools/verify-readme-release-evidence.ts
           pnpm exec tsx tools/check-readme-parity.ts
           STATUS_COMMIT=$(node -e "const fs=require('node:fs'); const status=JSON.parse(fs.readFileSync('docs/readme-status.json')); if(!/^[0-9a-f]{40}$/.test(status.sourceCommit)) process.exit(1); process.stdout.write(status.sourceCommit)")
           git cat-file -e "$STATUS_COMMIT^{commit}"
@@ -85,8 +90,7 @@ jobs:
                 package.before.json \
                 terminal.txt \
                 fix.patch \
-                package.after.json \
-                terminal.svg; do
+                package.after.json; do
                 git diff --no-index --exit-code -- \
                   "$PINNED_SOURCE_DIR/docs/assets/demo/$PINNED_ASSET" \
                   "docs/assets/demo/$PINNED_ASSET"

--- a/.github/workflows/npm-bootstrap.yml
+++ b/.github/workflows/npm-bootstrap.yml
@@ -17,19 +17,21 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: npm-bootstrap-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   bootstrap:
-    name: Establish npm ownership and integrity contract
+    name: Prepare and validate the exact bootstrap candidate
     if: vars.NPM_BOOTSTRAP_ENABLED == 'true' && inputs.confirm == 'BOOTSTRAP'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: npm-bootstrap
-    concurrency:
-      group: npm-bootstrap-${{ github.repository }}
-      cancel-in-progress: false
     permissions:
       actions: read
       contents: read
+    outputs:
+      needs-publish: ${{ steps.registry.outputs.needs-publish }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -58,6 +60,28 @@ jobs:
           gh api -H 'Accept: application/vnd.github+json' \
             "repos/$REPOSITORY/actions/workflows/ci.yml/runs?head_sha=$SOURCE_SHA&event=push&branch=main&status=completed&per_page=100" \
             > "$RUNNER_TEMP/ci-runs.json"
+          jq -e --arg repository "$REPOSITORY" --arg sha "$SOURCE_SHA" '
+            [.workflow_runs[] | select(
+              .name == "CI" and
+              .path == ".github/workflows/ci.yml" and
+              .head_sha == $sha and
+              .event == "push" and
+              .head_branch == "main" and
+              .head_repository.full_name == $repository and
+              .status == "completed" and
+              .conclusion == "success" and
+              (.id | type == "number") and .id > 0 and
+              (.run_number | type == "number") and .run_number > 0 and
+              .run_number == (.run_number | floor) and
+              (.run_attempt | type == "number") and .run_attempt > 0 and
+              .run_attempt == (.run_attempt | floor)
+            )] as $runs |
+            ($runs | length) >= 1 and
+            (($runs | sort_by(.run_number, .run_attempt) | last) as $newest |
+              [$runs[] | select(
+                .run_number == $newest.run_number and .run_attempt == $newest.run_attempt
+              )] | length == 1)
+          ' "$RUNNER_TEMP/ci-runs.json" >/dev/null
           node tools/release/release-state.mjs verify-ci \
             --runs "$RUNNER_TEMP/ci-runs.json" \
             --sha "$SOURCE_SHA" \
@@ -85,26 +109,54 @@ jobs:
             --arg name "$ANCHOR_NAME" "$RUNNER_TEMP/bootstrap-artifacts.json")
           [[ "$COUNT" -le 1 ]]
           if [[ "$COUNT" == 0 ]]; then
+            if npm view "scriptspect@$VERSION" version --json \
+              > "$RUNNER_TEMP/orphaned-bootstrap-version.raw.json" \
+              2> "$RUNNER_TEMP/orphaned-bootstrap-version.err"; then
+              node tools/release/verify-npm-bootstrap-state.mjs normalize \
+                --input "$RUNNER_TEMP/orphaned-bootstrap-version.raw.json" --type string \
+                > "$RUNNER_TEMP/orphaned-bootstrap-version.txt"
+              [[ "$(cat "$RUNNER_TEMP/orphaned-bootstrap-version.txt")" == "$VERSION" ]]
+              echo 'published bootstrap version exists without the retained anchor' >&2
+              exit 1
+            fi
+            grep -Eq 'E404|404 Not Found' "$RUNNER_TEMP/orphaned-bootstrap-version.err"
             echo 'recovered=false' >> "$GITHUB_OUTPUT"
             exit 0
           fi
           mkdir -p "$RUNNER_TEMP/bootstrap"
-          ARTIFACT_ID=$(jq -er --arg name "$ANCHOR_NAME" \
-            '.artifacts[] | select(.expired == false and .name == $name) | .id' \
+          ARTIFACT_RUN_ID=$(jq -er --arg name "$ANCHOR_NAME" \
+            '.artifacts[] | select(.expired == false and .name == $name) |
+              .workflow_run.id | select(type == "number")' \
             "$RUNNER_TEMP/bootstrap-artifacts.json")
           gh api -H 'Accept: application/vnd.github+json' \
+            "repos/$REPOSITORY/actions/runs/$ARTIFACT_RUN_ID" \
+            > "$RUNNER_TEMP/bootstrap-artifact-run.json"
+          gh api -H 'Accept: application/vnd.github+json' \
+            "repos/$REPOSITORY/actions/workflows/npm-bootstrap.yml" \
+            > "$RUNNER_TEMP/bootstrap-workflow.json"
+          gh api -H 'Accept: application/vnd.github+json' \
+            "repos/$REPOSITORY" > "$RUNNER_TEMP/bootstrap-repository.json"
+          node tools/release/verify-npm-bootstrap-anchor.mjs provenance \
+            --artifacts "$RUNNER_TEMP/bootstrap-artifacts.json" \
+            --run "$RUNNER_TEMP/bootstrap-artifact-run.json" \
+            --workflow "$RUNNER_TEMP/bootstrap-workflow.json" \
+            --repository "$RUNNER_TEMP/bootstrap-repository.json" \
+            --artifact-name "$ANCHOR_NAME" --repository-name "$REPOSITORY" \
+            --source-sha "$SOURCE_SHA" \
+            > "$RUNNER_TEMP/verified-bootstrap-artifact.json"
+          ARTIFACT_ID=$(jq -er '.artifactId | select(type == "number")' \
+            "$RUNNER_TEMP/verified-bootstrap-artifact.json")
+          ARTIFACT_DIGEST=$(jq -er \
+            '.artifactDigest | select(test("^sha256:[0-9a-f]{64}$"))' \
+            "$RUNNER_TEMP/verified-bootstrap-artifact.json")
+          gh api -H 'Accept: application/vnd.github+json' \
             "repos/$REPOSITORY/actions/artifacts/$ARTIFACT_ID/zip" > "$RUNNER_TEMP/bootstrap-anchor.zip"
+          [[ "sha256:$(sha256sum "$RUNNER_TEMP/bootstrap-anchor.zip" | cut -d' ' -f1)" == \
+            "$ARTIFACT_DIGEST" ]]
           unzip -q "$RUNNER_TEMP/bootstrap-anchor.zip" -d "$RUNNER_TEMP/bootstrap"
-          jq -e --arg source "$SOURCE_SHA" --arg version "$VERSION" '
-            .schemaVersion == "scriptspect-bootstrap-anchor/v1" and
-            .sourceCommit == $source and .version == $version and
-            (.tarball.basename | test("^scriptspect-.*\\.tgz$")) and
-            (.tarball.sha256 | test("^[0-9a-f]{64}$")) and
-            (.distTagsBeforeDigest | test("^[0-9a-f]{64}$"))
-          ' "$RUNNER_TEMP/bootstrap/bootstrap-anchor.json" >/dev/null
-          (cd "$RUNNER_TEMP/bootstrap" && sha256sum --check SHA256SUMS)
-          [[ "$(sha256sum "$RUNNER_TEMP/bootstrap/dist-tags-before.json" | cut -d' ' -f1)" == \
-            "$(jq -er '.distTagsBeforeDigest' "$RUNNER_TEMP/bootstrap/bootstrap-anchor.json")" ]]
+          node tools/release/verify-npm-bootstrap-anchor.mjs files \
+            --directory "$RUNNER_TEMP/bootstrap" --source-sha "$SOURCE_SHA" --version "$VERSION" \
+            > "$RUNNER_TEMP/verified-bootstrap-anchor-files.json"
           echo 'recovered=true' >> "$GITHUB_OUTPUT"
       - name: Version first, then build and pack the bootstrap prerelease once
         if: steps.anchor.outputs.recovered != 'true'
@@ -118,14 +170,42 @@ jobs:
           pnpm install --frozen-lockfile
           npm version "$VERSION" --no-git-tag-version --allow-same-version
           pnpm build
+          mkdir -p "$RUNNER_TEMP/bootstrap-first-build"
+          cp -R dist schema "$RUNNER_TEMP/bootstrap-first-build/"
           pnpm exec vitest run
+          pnpm build
+          diff -qr "$RUNNER_TEMP/bootstrap-first-build/dist" dist
+          diff -qr "$RUNNER_TEMP/bootstrap-first-build/schema" schema
           mkdir -p "$RUNNER_TEMP/bootstrap"
-          npm pack --pack-destination "$RUNNER_TEMP/bootstrap"
+          PACKAGE_STAGE="$RUNNER_TEMP/package-stage"
+          test ! -e "$PACKAGE_STAGE"
+          mkdir -p "$PACKAGE_STAGE"
+          git archive "$SOURCE_SHA" | tar -x -C "$PACKAGE_STAGE"
+          cp package.json "$PACKAGE_STAGE/package.json"
+          rm -rf "$PACKAGE_STAGE/dist" "$PACKAGE_STAGE/schema"
+          cp -R dist schema "$PACKAGE_STAGE/"
+          jq -e --arg version "$VERSION" \
+            '.name == "scriptspect" and .version == $version' \
+            "$PACKAGE_STAGE/package.json" >/dev/null
+          node tools/release/generate-package-readmes.mjs \
+            --version "$VERSION" --source-commit "$SOURCE_SHA" --channel bootstrap \
+            --english "$PACKAGE_STAGE/README.md" \
+            --chinese "$PACKAGE_STAGE/README.zh-CN.md"
+          git diff --exit-code -- README.md README.zh-CN.md
+          (cd "$PACKAGE_STAGE" && pnpm pack --pack-destination "$RUNNER_TEMP/bootstrap")
           TARBALL=$(find "$RUNNER_TEMP/bootstrap" -maxdepth 1 -name 'scriptspect-*.tgz' -print -quit)
           test -f "$TARBALL"
           TARBALL_BASENAME=$(basename "$TARBALL")
           (cd "$RUNNER_TEMP/bootstrap" && sha256sum "$TARBALL_BASENAME" > SHA256SUMS)
-          npm dist-tag ls scriptspect --json > "$RUNNER_TEMP/bootstrap/dist-tags-before.json" 2>/dev/null || printf '{}\n' > "$RUNNER_TEMP/bootstrap/dist-tags-before.json"
+          if ! npm view scriptspect dist-tags --json \
+            > "$RUNNER_TEMP/dist-tags-before.raw.json" \
+            2> "$RUNNER_TEMP/dist-tags-before.err"; then
+            grep -Eq 'E404|404 Not Found' "$RUNNER_TEMP/dist-tags-before.err"
+            printf '{}\n' > "$RUNNER_TEMP/dist-tags-before.raw.json"
+          fi
+          node tools/release/verify-npm-bootstrap-state.mjs normalize \
+            --input "$RUNNER_TEMP/dist-tags-before.raw.json" --type object \
+            > "$RUNNER_TEMP/bootstrap/dist-tags-before.json"
           jq -n --arg sourceCommit "$SOURCE_SHA" --arg version "$VERSION" \
             --arg basename "$TARBALL_BASENAME" \
             --arg sha256 "$(sha256sum "$TARBALL" | cut -d' ' -f1)" \
@@ -133,6 +213,9 @@ jobs:
             {schemaVersion:"scriptspect-bootstrap-anchor/v1",sourceCommit:$sourceCommit,version:$version,
               tarball:{basename:$basename,sha256:$sha256},distTagsBeforeDigest:$distTagsBeforeDigest}
           ' > "$RUNNER_TEMP/bootstrap/bootstrap-anchor.json"
+          node tools/release/verify-npm-bootstrap-anchor.mjs files \
+            --directory "$RUNNER_TEMP/bootstrap" --source-sha "$SOURCE_SHA" --version "$VERSION" \
+            > "$RUNNER_TEMP/verified-built-anchor-files.json"
       - name: Persist the exact bootstrap candidate before npm publication
         if: steps.anchor.outputs.recovered != 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -147,10 +230,23 @@ jobs:
           if-no-files-found: error
       - name: Fresh-install and smoke-test the exact local tarball
         env:
+          SOURCE_SHA: ${{ inputs.source-sha }}
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
           TARBALL=$(find "$RUNNER_TEMP/bootstrap" -maxdepth 1 -name 'scriptspect-*.tgz' -print -quit)
+          EXPECTED_READMES="$RUNNER_TEMP/bootstrap-expected-readmes"
+          node tools/release/generate-package-readmes.mjs \
+            --version "$VERSION" --source-commit "$SOURCE_SHA" --channel bootstrap \
+            --english "$EXPECTED_READMES/README.md" \
+            --chinese "$EXPECTED_READMES/README.zh-CN.md"
+          for README in README.md README.zh-CN.md; do
+            [[ "$(tar -tf "$TARBALL" | grep -Fxc "package/$README")" == 1 ]]
+            tar -xOf "$TARBALL" "package/$README" > "$RUNNER_TEMP/bootstrap-packed-$README"
+            cmp "$EXPECTED_READMES/$README" "$RUNNER_TEMP/bootstrap-packed-$README"
+          done
+          tar -xOf "$TARBALL" package/package.json | jq -e --arg version "$VERSION" \
+            '.name == "scriptspect" and .version == $version' >/dev/null
           INSTALL_ROOT="$RUNNER_TEMP/bootstrap/local-install"
           FIXTURE="$RUNNER_TEMP/bootstrap/local-fixture"
           mkdir -p "$INSTALL_ROOT" "$FIXTURE"
@@ -172,50 +268,376 @@ jobs:
           )
           grep -Eq '^exit-code=0$' "$RUNNER_TEMP/bootstrap/local-action-output"
           test -s "$RUNNER_TEMP/bootstrap/local-action-summary"
-      - name: Verify npm ownership or package-name availability
+      - name: Gate the exact candidate against the public registry
+        id: registry
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
-        run: |
-          set -euo pipefail
-          test -n "$NODE_AUTH_TOKEN"
-          OWNER=$(npm whoami)
-          if npm view scriptspect name --json > "$RUNNER_TEMP/package-name.json" 2> "$RUNNER_TEMP/package-name.err"; then
-            npm owner ls scriptspect --json > "$RUNNER_TEMP/package-owners.json"
-            jq -e --arg owner "$OWNER" 'has($owner)' "$RUNNER_TEMP/package-owners.json" >/dev/null
-          else
-            grep -Eq 'E404|404 Not Found' "$RUNNER_TEMP/package-name.err"
-          fi
-      - name: Publish once or verify the already-published exact version
-        id: publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
+          EXPECTED_NPM_OWNER: Tom409114
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org
+          SOURCE_SHA: ${{ inputs.source-sha }}
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          test -n "$NODE_AUTH_TOKEN"
           (cd "$RUNNER_TEMP/bootstrap" && sha256sum --check SHA256SUMS)
-          LATEST_BEFORE=$(jq -r '.latest // ""' "$RUNNER_TEMP/bootstrap/dist-tags-before.json")
-          if npm view "scriptspect@$VERSION" version --json > "$RUNNER_TEMP/existing-version.json" 2> "$RUNNER_TEMP/existing-version.err"; then
-            [[ "$(jq -r . "$RUNNER_TEMP/existing-version.json")" == "$VERSION" ]]
-            echo 'already-published=true' >> "$GITHUB_OUTPUT"
+          if npm view "scriptspect@$VERSION" version --json \
+            > "$RUNNER_TEMP/existing-version.raw.json" \
+            2> "$RUNNER_TEMP/existing-version.err"; then
+            jq -er '
+              if type == "array" and length == 1 then .[0] else . end |
+              select(type == "string")
+            ' "$RUNNER_TEMP/existing-version.raw.json" > "$RUNNER_TEMP/existing-version.txt"
+            [[ "$(cat "$RUNNER_TEMP/existing-version.txt")" == "$VERSION" ]]
+            echo 'needs-publish=false' >> "$GITHUB_OUTPUT"
           else
             grep -Eq 'E404|404 Not Found' "$RUNNER_TEMP/existing-version.err"
-            TARBALL=$(find "$RUNNER_TEMP/bootstrap" -maxdepth 1 -name 'scriptspect-*.tgz' -print -quit)
-            npm publish "$TARBALL" --tag bootstrap --access public
-            [[ "$(npm view scriptspect dist-tags.bootstrap)" == "$VERSION" ]]
-            echo 'already-published=false' >> "$GITHUB_OUTPUT"
+            git fetch --no-tags origin main
+            [[ "$(git rev-parse origin/main)" == "$SOURCE_SHA" ]]
+            echo 'needs-publish=true' >> "$GITHUB_OUTPUT"
           fi
-          [[ "$(npm view "scriptspect@$VERSION" version)" == "$VERSION" ]]
-          npm dist-tag ls scriptspect --json > "$RUNNER_TEMP/dist-tags-after.json"
-          LATEST_AFTER=$(jq -r '.latest // ""' "$RUNNER_TEMP/dist-tags-after.json")
-          [[ "$LATEST_BEFORE" == "$LATEST_AFTER" ]]
+
+          if npm view scriptspect name --json \
+            > "$RUNNER_TEMP/package-name.json" 2> "$RUNNER_TEMP/package-name.err"; then
+            jq -e '
+              if type == "array" and length == 1 then .[0] else . end |
+              . == "scriptspect"
+            ' "$RUNNER_TEMP/package-name.json" >/dev/null
+            npm view scriptspect maintainers --json \
+              > "$RUNNER_TEMP/public-package-maintainers.json"
+            jq -e --arg expected "${EXPECTED_NPM_OWNER,,}" '
+              def rows:
+                if type == "array" and length == 1 and (.[0] | type) == "array" then .[0]
+                elif type == "array" then .
+                else [.] end;
+              [rows[] |
+                if type == "object" then .name
+                elif type == "string" then split(" ")[0]
+                else empty end |
+                ascii_downcase] |
+              unique == [$expected]
+            ' "$RUNNER_TEMP/public-package-maintainers.json" >/dev/null
+          else
+            grep -Eq 'E404|404 Not Found' "$RUNNER_TEMP/package-name.err"
+          fi
+      - name: Hand the verified candidate to a fresh publisher runner
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-bootstrap-handoff-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/bootstrap/scriptspect-*.tgz
+            ${{ runner.temp }}/bootstrap/SHA256SUMS
+            ${{ runner.temp }}/bootstrap/bootstrap-anchor.json
+            ${{ runner.temp }}/bootstrap/dist-tags-before.json
+          retention-days: 1
+          if-no-files-found: error
+
+  publish_bootstrap:
+    name: Publish from a fresh credential-isolated runner
+    needs: [bootstrap]
+    if: needs.bootstrap.outputs.needs-publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: npm-bootstrap
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Download the current-run bootstrap handoff
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-bootstrap-handoff-${{ github.run_id }}
+          path: ${{ runner.temp }}/bootstrap-handoff
+      - name: Revalidate current main, handoff bytes, package name, and public owner
+        id: fresh-registry
+        env:
+          EXPECTED_NPM_OWNER: Tom409114
+          GH_TOKEN: ${{ github.token }}
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org
+          REPOSITORY: ${{ github.repository }}
+          SOURCE_SHA: ${{ inputs.source-sha }}
+          VERSION: ${{ inputs.version }}
+          WORKFLOW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_REF" == refs/heads/main ]]
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$VERSION" =~ ^0\.0\.0-bootstrap\.[0-9]+$ ]]
+          HANDOFF="$RUNNER_TEMP/bootstrap-handoff"
+          TARBALL="scriptspect-$VERSION.tgz"
+          find "$HANDOFF" -maxdepth 1 -type f -printf '%f\n' | sort \
+            > "$RUNNER_TEMP/handoff-files.txt"
+          printf '%s\n' SHA256SUMS bootstrap-anchor.json dist-tags-before.json "$TARBALL" | sort \
+            > "$RUNNER_TEMP/expected-handoff-files.txt"
+          diff -u "$RUNNER_TEMP/expected-handoff-files.txt" "$RUNNER_TEMP/handoff-files.txt"
+          (cd "$HANDOFF" && sha256sum --check SHA256SUMS)
+          TARBALL_SHA=$(sha256sum "$HANDOFF/$TARBALL" | cut -d' ' -f1)
+          DIST_TAGS_BEFORE_SHA=$(sha256sum "$HANDOFF/dist-tags-before.json" | cut -d' ' -f1)
+          jq -e --arg source "$SOURCE_SHA" --arg version "$VERSION" \
+            --arg tarball "$TARBALL" --arg sha "$TARBALL_SHA" \
+            --arg tags "$DIST_TAGS_BEFORE_SHA" '
+            .schemaVersion == "scriptspect-bootstrap-anchor/v1" and
+            .sourceCommit == $source and .version == $version and
+            .tarball == {basename:$tarball,sha256:$sha} and
+            .distTagsBeforeDigest == $tags
+          ' "$HANDOFF/bootstrap-anchor.json" >/dev/null
+          tar -xOf "$HANDOFF/$TARBALL" package/package.json | \
+            jq -e --arg version "$VERSION" \
+              '.name == "scriptspect" and .version == $version' >/dev/null
+          for README in README.md README.zh-CN.md; do
+            [[ "$(tar -tf "$HANDOFF/$TARBALL" | grep -Fxc "package/$README")" == 1 ]]
+            tar -xOf "$HANDOFF/$TARBALL" "package/$README" \
+              > "$RUNNER_TEMP/fresh-$README"
+            grep -F "scriptspect@$VERSION" "$RUNNER_TEMP/fresh-$README"
+            grep -F "$SOURCE_SHA" "$RUNNER_TEMP/fresh-$README"
+            ! grep -F "uses: Tom409114/scriptspect@v$VERSION" "$RUNNER_TEMP/fresh-$README"
+          done
+
+          if npm view "scriptspect@$VERSION" version --json \
+            > "$RUNNER_TEMP/fresh-version.json" 2> "$RUNNER_TEMP/fresh-version.err"; then
+            jq -e --arg version "$VERSION" '
+              (if type == "array" and length == 1 then .[0] else . end) == $version
+            ' "$RUNNER_TEMP/fresh-version.json" >/dev/null
+            echo 'publish-now=false' >> "$GITHUB_OUTPUT"
+          else
+            grep -Eq 'E404|404 Not Found' "$RUNNER_TEMP/fresh-version.err"
+            gh api -H 'Accept: application/vnd.github+json' \
+              "repos/$REPOSITORY/git/ref/heads/main" > "$RUNNER_TEMP/current-main.json"
+            jq -e --arg source "$SOURCE_SHA" --arg workflow "$WORKFLOW_SHA" '
+              .ref == "refs/heads/main" and .object.type == "commit" and
+              .object.sha == $source and .object.sha == $workflow
+            ' "$RUNNER_TEMP/current-main.json" >/dev/null
+            echo 'publish-now=true' >> "$GITHUB_OUTPUT"
+          fi
+
+          if npm view scriptspect name --json \
+            > "$RUNNER_TEMP/fresh-package-name.json" \
+            2> "$RUNNER_TEMP/fresh-package-name.err"; then
+            npm view scriptspect maintainers --json \
+              > "$RUNNER_TEMP/fresh-maintainers.json"
+            jq -e --arg expected "${EXPECTED_NPM_OWNER,,}" '
+              def rows:
+                if type == "array" and length == 1 and (.[0] | type) == "array" then .[0]
+                elif type == "array" then .
+                else [.] end;
+              [rows[] |
+                if type == "object" then .name
+                elif type == "string" then split(" ")[0]
+                else empty end |
+                ascii_downcase] |
+              unique == [$expected]
+            ' "$RUNNER_TEMP/fresh-maintainers.json" >/dev/null
+            echo 'package-existed=true' >> "$GITHUB_OUTPUT"
+          else
+            grep -Eq 'E404|404 Not Found' "$RUNNER_TEMP/fresh-package-name.err"
+            echo 'package-existed=false' >> "$GITHUB_OUTPUT"
+          fi
+          test ! -e "$RUNNER_TEMP/npm-bootstrap-credential"
+          mkdir "$RUNNER_TEMP/npm-bootstrap-credential"
+      - name: Publish the bootstrap candidate with the one-time credential
+        if: steps.fresh-registry.outputs.publish-now == 'true'
+        env:
+          EXPECTED_NPM_OWNER: Tom409114
+          GH_TOKEN: ${{ github.token }}
+          NPM_CONFIG_IGNORE_SCRIPTS: 'true'
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
+          PACKAGE_EXISTED: ${{ steps.fresh-registry.outputs.package-existed }}
+          REPOSITORY: ${{ github.repository }}
+          SOURCE_SHA: ${{ inputs.source-sha }}
+          VERSION: ${{ inputs.version }}
+          WORKFLOW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP/npm-bootstrap-credential"
+          test -n "$NODE_AUTH_TOKEN"
+          if npm view "scriptspect@$VERSION" version --json \
+            > "$RUNNER_TEMP/raced-version.json" 2> "$RUNNER_TEMP/raced-version.err"; then
+            jq -e --arg version "$VERSION" '
+              (if type == "array" and length == 1 then .[0] else . end) == $version
+            ' "$RUNNER_TEMP/raced-version.json" >/dev/null
+            exit 0
+          fi
+          grep -Eq 'E404|404 Not Found' "$RUNNER_TEMP/raced-version.err"
+          gh api -H 'Accept: application/vnd.github+json' \
+            "repos/$REPOSITORY/git/ref/heads/main" > "$RUNNER_TEMP/publish-main.json"
+          jq -e --arg source "$SOURCE_SHA" --arg workflow "$WORKFLOW_SHA" '
+            .ref == "refs/heads/main" and .object.type == "commit" and
+            .object.sha == $source and .object.sha == $workflow
+          ' "$RUNNER_TEMP/publish-main.json" >/dev/null
+          OWNER=$(npm whoami)
+          [[ "${OWNER,,}" == "${EXPECTED_NPM_OWNER,,}" ]]
+          if [[ "$PACKAGE_EXISTED" == true ]]; then
+            npm view scriptspect maintainers --json \
+              > "$RUNNER_TEMP/credential-maintainers.json"
+            jq -e --arg expected "${EXPECTED_NPM_OWNER,,}" '
+              def rows:
+                if type == "array" and length == 1 and (.[0] | type) == "array" then .[0]
+                elif type == "array" then .
+                else [.] end;
+              [rows[] |
+                if type == "object" then .name
+                elif type == "string" then split(" ")[0]
+                else empty end |
+                ascii_downcase] |
+              unique == [$expected]
+            ' "$RUNNER_TEMP/credential-maintainers.json" >/dev/null
+          else
+            if npm view scriptspect name --json \
+              > "$RUNNER_TEMP/raced-package-name.json" \
+              2> "$RUNNER_TEMP/raced-package-name.err"; then
+              echo 'scriptspect package ownership changed after the fresh preflight' >&2
+              exit 1
+            fi
+            grep -Eq 'E404|404 Not Found' "$RUNNER_TEMP/raced-package-name.err"
+          fi
+          npm publish "$RUNNER_TEMP/bootstrap-handoff/scriptspect-$VERSION.tgz" \
+            --tag bootstrap --access public
+      - name: Wait for the exact public bootstrap version without a credential
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          for attempt in {1..12}; do
+            if npm view "scriptspect@$VERSION" version --json \
+              > "$RUNNER_TEMP/fresh-published-version.json" \
+              2> "$RUNNER_TEMP/fresh-published-version.err"; then
+              jq -e --arg version "$VERSION" '
+                (if type == "array" and length == 1 then .[0] else . end) == $version
+              ' "$RUNNER_TEMP/fresh-published-version.json" >/dev/null
+              exit 0
+            fi
+            grep -Eq 'E404|404 Not Found' "$RUNNER_TEMP/fresh-published-version.err"
+            sleep 5
+          done
+          echo 'exact bootstrap version did not become public in time' >&2
+          exit 1
+
+  verify_bootstrap:
+    name: Verify the public bootstrap package without a credential
+    needs: [bootstrap, publish_bootstrap]
+    if: >-
+      always() &&
+      needs.bootstrap.result == 'success' &&
+      (needs.bootstrap.outputs.needs-publish != 'true' ||
+      needs.publish_bootstrap.result == 'success')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.source-sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Download the current-run bootstrap handoff for public verification
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-bootstrap-handoff-${{ github.run_id }}
+          path: ${{ runner.temp }}/bootstrap
+      - name: Revalidate the exact current-run handoff
+        env:
+          SOURCE_SHA: ${{ inputs.source-sha }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          TARBALL="scriptspect-$VERSION.tgz"
+          find "$RUNNER_TEMP/bootstrap" -maxdepth 1 -type f -printf '%f\n' | sort \
+            > "$RUNNER_TEMP/verify-handoff-files.txt"
+          printf '%s\n' SHA256SUMS bootstrap-anchor.json dist-tags-before.json "$TARBALL" | sort \
+            > "$RUNNER_TEMP/expected-verify-handoff-files.txt"
+          diff -u "$RUNNER_TEMP/expected-verify-handoff-files.txt" \
+            "$RUNNER_TEMP/verify-handoff-files.txt"
+          node tools/release/verify-npm-bootstrap-anchor.mjs files \
+            --directory "$RUNNER_TEMP/bootstrap" --source-sha "$SOURCE_SHA" --version "$VERSION" \
+            > "$RUNNER_TEMP/verified-handoff-anchor-files.json"
+      - name: Fresh-install and smoke-test the exact local tarball
+        env:
+          SOURCE_SHA: ${{ inputs.source-sha }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          TARBALL=$(find "$RUNNER_TEMP/bootstrap" -maxdepth 1 -name 'scriptspect-*.tgz' -print -quit)
+          EXPECTED_READMES="$RUNNER_TEMP/bootstrap-expected-readmes"
+          node tools/release/generate-package-readmes.mjs \
+            --version "$VERSION" --source-commit "$SOURCE_SHA" --channel bootstrap \
+            --english "$EXPECTED_READMES/README.md" \
+            --chinese "$EXPECTED_READMES/README.zh-CN.md"
+          for README in README.md README.zh-CN.md; do
+            [[ "$(tar -tf "$TARBALL" | grep -Fxc "package/$README")" == 1 ]]
+            tar -xOf "$TARBALL" "package/$README" > "$RUNNER_TEMP/bootstrap-packed-$README"
+            cmp "$EXPECTED_READMES/$README" "$RUNNER_TEMP/bootstrap-packed-$README"
+          done
+          tar -xOf "$TARBALL" package/package.json | jq -e --arg version "$VERSION" \
+            '.name == "scriptspect" and .version == $version' >/dev/null
+          INSTALL_ROOT="$RUNNER_TEMP/bootstrap/local-install"
+          FIXTURE="$RUNNER_TEMP/bootstrap/local-fixture"
+          mkdir -p "$INSTALL_ROOT" "$FIXTURE"
+          npm init -y --prefix "$INSTALL_ROOT" >/dev/null
+          npm install --prefix "$INSTALL_ROOT" "$TARBALL" --ignore-scripts
+          [[ "$(node "$INSTALL_ROOT/node_modules/scriptspect/dist/cli.mjs" --version)" == "$VERSION" ]]
+          test -f "$INSTALL_ROOT/node_modules/scriptspect/schema/config.schema.json"
+          test -f "$INSTALL_ROOT/node_modules/scriptspect/schema/output.schema.json"
+          test -f "$INSTALL_ROOT/node_modules/scriptspect/dist/action.mjs"
+          printf '{"name":"bootstrap-smoke","scripts":{"build":"node -e \\"process.exit(0)\\""}}\n' > "$FIXTURE/package.json"
+          : > "$RUNNER_TEMP/bootstrap/local-action-output"
+          : > "$RUNNER_TEMP/bootstrap/local-action-summary"
+          (
+            cd "$FIXTURE"
+            GITHUB_WORKSPACE="$FIXTURE" INPUT_PATH=. \
+              GITHUB_OUTPUT="$RUNNER_TEMP/bootstrap/local-action-output" \
+              GITHUB_STEP_SUMMARY="$RUNNER_TEMP/bootstrap/local-action-summary" \
+              node "$INSTALL_ROOT/node_modules/scriptspect/dist/action.mjs"
+          )
+          grep -Eq '^exit-code=0$' "$RUNNER_TEMP/bootstrap/local-action-output"
+          test -s "$RUNNER_TEMP/bootstrap/local-action-summary"
+      - name: Verify exact public bootstrap registry state
+        env:
+          EXPECTED_NPM_OWNER: Tom409114
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          (cd "$RUNNER_TEMP/bootstrap" && sha256sum --check SHA256SUMS)
+          npm view "scriptspect@$VERSION" version --json \
+            > "$RUNNER_TEMP/public-version.raw.json"
+          node tools/release/verify-npm-bootstrap-state.mjs normalize \
+            --input "$RUNNER_TEMP/public-version.raw.json" --type string \
+            > "$RUNNER_TEMP/public-version.txt"
+          [[ "$(cat "$RUNNER_TEMP/public-version.txt")" == "$VERSION" ]]
+          npm view scriptspect dist-tags --json \
+            > "$RUNNER_TEMP/dist-tags-after.raw.json"
+          node tools/release/verify-npm-bootstrap-state.mjs normalize \
+            --input "$RUNNER_TEMP/dist-tags-after.raw.json" --type object \
+            > "$RUNNER_TEMP/bootstrap/dist-tags-after.json"
+          npm view scriptspect maintainers --json \
+            > "$RUNNER_TEMP/bootstrap/package-maintainers.json"
+          node tools/release/verify-npm-bootstrap-state.mjs \
+            --owners "$RUNNER_TEMP/bootstrap/package-maintainers.json" \
+            --owner "$EXPECTED_NPM_OWNER" \
+            --before "$RUNNER_TEMP/bootstrap/dist-tags-before.json" \
+            --after "$RUNNER_TEMP/bootstrap/dist-tags-after.json" \
+            --version "$VERSION" \
+            > "$RUNNER_TEMP/bootstrap/verified-registry-state.json"
       - name: Verify registry bytes, canonical tree, CLI, schemas, and Action
         env:
           VERSION: ${{ inputs.version }}
           SOURCE_SHA: ${{ inputs.source-sha }}
         run: |
           set -euo pipefail
-          npm view "scriptspect@$VERSION" --json > "$RUNNER_TEMP/bootstrap/registry-metadata.json"
+          npm view "scriptspect@$VERSION" --json > "$RUNNER_TEMP/registry-metadata.raw.json"
+          node tools/release/verify-npm-bootstrap-state.mjs normalize \
+            --input "$RUNNER_TEMP/registry-metadata.raw.json" --type object \
+            > "$RUNNER_TEMP/bootstrap/registry-metadata.json"
           REGISTRY_URL=$(jq -er '.dist.tarball' "$RUNNER_TEMP/bootstrap/registry-metadata.json")
           REGISTRY_SRI=$(jq -er '.dist.integrity' "$RUNNER_TEMP/bootstrap/registry-metadata.json")
           curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors "$REGISTRY_URL" -o "$RUNNER_TEMP/bootstrap/registry.tgz"
@@ -310,5 +732,8 @@ jobs:
             ${{ runner.temp }}/bootstrap/canonical-tree.json
             ${{ runner.temp }}/bootstrap/comparator-source-bundle.json
             ${{ runner.temp }}/bootstrap/audit-signatures.json
+            ${{ runner.temp }}/bootstrap/dist-tags-after.json
+            ${{ runner.temp }}/bootstrap/package-maintainers.json
+            ${{ runner.temp }}/bootstrap/verified-registry-state.json
           retention-days: 90
           if-no-files-found: error

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -209,7 +209,10 @@ jobs:
           (cd "$RUNNER_TEMP/release" && sha256sum --check SHA256SUMS)
           TARBALL="scriptspect-$VERSION.tgz"
           tar -xOf "$RUNNER_TEMP/release/$TARBALL" package/package.json | \
-            jq -e '.repository == {type:"git",url:"git+https://github.com/Tom409114/scriptspect.git"}' >/dev/null
+            jq -e --arg version "$VERSION" '
+              .name == "scriptspect" and .version == $version and
+              .repository == {type:"git",url:"git+https://github.com/Tom409114/scriptspect.git"}
+            ' >/dev/null
           node tools/release/release-state.mjs validate-candidate \
             "$RUNNER_TEMP/release/candidate-manifest.json" >/dev/null
           node tools/release/release-state.mjs validate-release \
@@ -239,6 +242,20 @@ jobs:
             "$RUNNER_TEMP/publish-anchors.json" > "$RUNNER_TEMP/verified-anchors.json"
           CANDIDATE_SRI=$(jq -er '.npmSRI' "$RUNNER_TEMP/verified-anchors.json")
           INTEGRITY_CONTRACT=docs/release/npm-integrity-contract.json
+
+          EXPECTED_READMES="$RUNNER_TEMP/release-expected-readmes"
+          node tools/release/generate-package-readmes.mjs \
+            --version "$VERSION" --source-commit "$SHA" --channel stable \
+            --english "$EXPECTED_READMES/README.md" \
+            --chinese "$EXPECTED_READMES/README.zh-CN.md"
+          for README in README.md README.zh-CN.md; do
+            [[ "$(tar -tf "$RUNNER_TEMP/release/$TARBALL" | grep -Fxc "package/$README")" == 1 ]]
+            tar -xOf "$RUNNER_TEMP/release/$TARBALL" "package/$README" \
+              > "$RUNNER_TEMP/release-packed-$README"
+            cmp "$EXPECTED_READMES/$README" "$RUNNER_TEMP/release-packed-$README"
+          done
+          grep -F "npx --yes scriptspect@$VERSION ." "$RUNNER_TEMP/release-packed-README.md"
+          ! grep -F 'pre-release source evaluation' "$RUNNER_TEMP/release-packed-README.md"
 
           npm install --global npm@11.12.1
           node tools/release/fetch-npm-artifact.mjs probe \
@@ -727,6 +744,27 @@ jobs:
           gh api -X PATCH -H 'Accept: application/vnd.github+json' \
             "repos/$REPOSITORY/check-runs/$INTENT_ID" --input "$RUNNER_TEMP/update-check.json" >/dev/null
 
+          # This is a handoff receipt for a later, protected README/status PR. It is
+          # created only after the consumed state is durable; this workflow never
+          # writes documentation directly to main.
+          jq -n \
+            --arg schemaVersion scriptspect-readme-release-receipt/v1 \
+            --arg repository "https://github.com/$REPOSITORY" \
+            --argjson intentCheckRunId "$INTENT_ID" \
+            --argjson finalVerificationAssetId "$FINAL_ASSET_ID" \
+            --arg finalVerificationDigest "$FINAL_DIGEST" \
+            --argjson publishRunId "$(jq -er '.npmPublished.publishRunId' "$RUNNER_TEMP/approved-consumed-state.json")" \
+            --slurpfile finalVerification "$RUNNER_TEMP/final-verification.json" '
+            {schemaVersion:$schemaVersion,repository:$repository,
+              intentCheckRunId:$intentCheckRunId,
+              finalVerificationAssetId:$finalVerificationAssetId,
+              finalVerificationDigest:$finalVerificationDigest,publishRunId:$publishRunId,
+              finalVerification:$finalVerification[0]}
+          ' > "$RUNNER_TEMP/readme-release-receipt.json"
+          node tools/release/release-state.mjs canonicalize-json \
+            "$RUNNER_TEMP/readme-release-receipt.json" \
+            --out "$RUNNER_TEMP/readme-release-receipt.json" >/dev/null
+
           # The latest marker is advisory, terminal-only, and monotonic across stale retries.
           LATEST_HTTP_STATUS=$(curl --silent --show-error \
             --output "$RUNNER_TEMP/current-latest-release.json" --write-out '%{http_code}' \
@@ -752,6 +790,14 @@ jobs:
           if [[ "$(jq -er '.action' "$RUNNER_TEMP/latest-promotion.json")" == promote ]]; then
             gh release edit "$TAG" --repo "$REPOSITORY" --latest
           fi
+
+      - name: Upload the terminal README handoff receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: readme-release-receipt-v${{ needs.publish.outputs.version }}
+          path: ${{ runner.temp }}/readme-release-receipt.json
+          if-no-files-found: error
+          retention-days: 90
 
   rollback-aliases:
     name: Roll back the durable alias plan after any later failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -396,6 +396,7 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm build
           pnpm exec vitest run
+          git diff --exit-code -- dist schema
       - name: Pack once and create the versioned candidate manifest
         if: steps.recover.outputs.needs-build == 'true'
         env:
@@ -406,9 +407,31 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/candidate"
-          pnpm pack --pack-destination "$RUNNER_TEMP/candidate"
+          PACKAGE_STAGE="$RUNNER_TEMP/package-stage"
+          test ! -e "$PACKAGE_STAGE"
+          mkdir -p "$PACKAGE_STAGE"
+          git archive "$SHA" | tar -x -C "$PACKAGE_STAGE"
+          rm -rf "$PACKAGE_STAGE/dist" "$PACKAGE_STAGE/schema"
+          cp -R dist schema "$PACKAGE_STAGE/"
+          jq -e --arg version "$VERSION" \
+            '.name == "scriptspect" and .version == $version' \
+            "$PACKAGE_STAGE/package.json" >/dev/null
+          node tools/release/generate-package-readmes.mjs \
+            --version "$VERSION" --source-commit "$SHA" --channel stable \
+            --english "$PACKAGE_STAGE/README.md" \
+            --chinese "$PACKAGE_STAGE/README.zh-CN.md"
+          git diff --exit-code -- README.md README.zh-CN.md
+          (cd "$PACKAGE_STAGE" && pnpm pack --pack-destination "$RUNNER_TEMP/candidate")
           TARBALL=$(find "$RUNNER_TEMP/candidate" -maxdepth 1 -name 'scriptspect-*.tgz' -printf '%f\n')
           [[ $(printf '%s\n' "$TARBALL" | sed '/^$/d' | wc -l) == 1 ]]
+          for README in README.md README.zh-CN.md; do
+            [[ "$(tar -tf "$RUNNER_TEMP/candidate/$TARBALL" | grep -Fxc "package/$README")" == 1 ]]
+            tar -xOf "$RUNNER_TEMP/candidate/$TARBALL" "package/$README" \
+              > "$RUNNER_TEMP/packed-$README"
+            cmp "$PACKAGE_STAGE/$README" "$RUNNER_TEMP/packed-$README"
+          done
+          grep -F "npx --yes scriptspect@$VERSION ." "$RUNNER_TEMP/packed-README.md"
+          ! grep -F 'pre-release source evaluation' "$RUNNER_TEMP/packed-README.md"
           SHA256=$(sha256sum "$RUNNER_TEMP/candidate/$TARBALL" | cut -d' ' -f1)
           SRI="sha512-$(openssl dgst -sha512 -binary "$RUNNER_TEMP/candidate/$TARBALL" | openssl base64 -A)"
           (cd "$RUNNER_TEMP/candidate" && sha256sum "$TARBALL" > SHA256SUMS)

--- a/README.md
+++ b/README.md
@@ -19,12 +19,14 @@ them. It identifies constructs that mean different things to `posix-sh`,
 Windows `cmd`, or optional `powershell`, points to the relevant span, and keeps
 automatic fixes behind explicit safety gates.
 
+<!-- readme-state:overview:start -->
 > [!IMPORTANT]
 > This repository is a **pre-release source evaluation**. The npm package and
 > public Action tag do not exist yet; the copy-paste paths below deliberately
 > use an immutable source commit.
 
 **[See the real demo](#before-result-and-after)** · **[Evaluate from source](#evaluate-from-source-pre-release)** · **[GitHub Actions](#github-actions-preview-pre-release)** · **[Rules](docs/rules/README.md)**
+<!-- readme-state:overview:end -->
 
 <!-- readme-section: why -->
 ## Why it is useful
@@ -83,6 +85,7 @@ post-write analysis, and a recovery journal; it never installs dependencies or
 rewrites a lockfile. Regenerate all demo assets with
 `pnpm exec tsx tools/generate-readme-demo.ts`.
 
+<!-- readme-state:evaluate:start -->
 <!-- readme-section: evaluate -->
 ## Evaluate from source (pre-release)
 
@@ -94,7 +97,7 @@ configuration, or I/O exits `2`.
 ```bash
 git clone https://github.com/Tom409114/scriptspect.git
 cd scriptspect
-git checkout 0898538abef5b054db6a20dc0ffe7fb9bb67e96b
+git checkout bf37b4132508c685a91cc16a9c0a3058c252502e
 corepack enable
 pnpm install --frozen-lockfile
 pnpm build
@@ -103,6 +106,7 @@ node dist/cli.mjs tests/fixtures/readme-demo
 
 There is deliberately no `npx scriptspect` quick start yet. The machine-readable
 release state is [docs/readme-status.json](docs/readme-status.json).
+<!-- readme-state:evaluate:end -->
 
 <!-- readme-section: cli -->
 ## CLI at a glance
@@ -123,6 +127,7 @@ node dist/cli.mjs explain PS010
 Presentation filters do not hide failure semantics: any configured `error`
 fails, and the unfiltered warning count is compared with `--max-warnings`.
 
+<!-- readme-state:action:start -->
 <!-- readme-section: action -->
 ## GitHub Actions preview (pre-release)
 
@@ -146,7 +151,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Tom409114/scriptspect
-          ref: 0898538abef5b054db6a20dc0ffe7fb9bb67e96b
+          ref: bf37b4132508c685a91cc16a9c0a3058c252502e
           path: .scriptspect
           persist-credentials: false
       - uses: ./.scriptspect
@@ -157,16 +162,17 @@ jobs:
 The Action writes annotations, a job summary, and numeric outputs named
 `exit-code`, `packages`, `scripts`, `errors`, `warnings`, and `advisories` before
 marking a finding run as failed. Its default mode is read-only.
+<!-- readme-state:action:end -->
 
-**Real hosted proof — not a mock screenshot.** On `main` at `0898538`, public
-[CI run #33449906358](https://github.com/Tom409114/scriptspect/actions/runs/33449906358)
+**Real hosted proof — not a mock screenshot.** On `main` at `bf37b413`, public
+[CI run #33467290054](https://github.com/Tom409114/scriptspect/actions/runs/33467290054)
 consumed `uses: ./` against both clean and broken fixtures. The clean consumer
 reported `1 package · 1 script · 0 errors`; the broken fixture emitted 2 check
 annotations, including `PS010: scripts.clean` on `package.json`.
 
 ![Generated card summarizing the verified hosted Action run](docs/assets/demo/action.svg)
 
-[Selectable Action evidence](docs/assets/demo/action.txt) · [Committed source evidence](docs/validation/readme-action-evidence.json) · [Open the hosted job](https://github.com/Tom409114/scriptspect/actions/runs/33449906358/job/99677215357)
+[Selectable Action evidence](docs/assets/demo/action.txt) · [Committed source evidence](docs/validation/readme-action-evidence.json) · [Open the hosted job](https://github.com/Tom409114/scriptspect/actions/runs/33467290054/job/99729679961)
 
 <!-- readme-section: config -->
 ## Minimal configuration
@@ -196,6 +202,7 @@ Contracts: [config JSON Schema](schema/config.schema.json) · [JSON output Schem
 <!-- readme-section: support -->
 ## Scope and honest limits
 
+<!-- readme-state:scope-table:start -->
 | Area | Current source-evaluation behavior |
 | --- | --- |
 | Projects | root `package.json` plus npm/Yarn/Bun workspaces and `pnpm-workspace.yaml` |
@@ -204,13 +211,16 @@ Contracts: [config JSON Schema](schema/config.schema.json) · [JSON output Schem
 | Output | stylish terminal text, versioned JSON, GitHub annotations + summary |
 | Fixes | dry-run plus provable safe/conditional rewrites; ambiguous cases stay manual |
 | Privacy | offline analysis; scripts are not executed; no telemetry |
-| Release | pre-release; no npm package or public Action reference yet |
+<!-- readme-state:scope-table:end -->
+<!-- readme-state:release-row:start -->
+**Release:** pre-release; no npm package or public Action reference yet.
+<!-- readme-state:release-row:end -->
 
 The homepage does not claim external adoption, measured precision, comparative
-superiority, hosted performance, or completed release gates. The
-[validation ledger](docs/validation/spec-compliance-2026-09-01.md) keeps
-repository-controlled work separate from evidence that only real users and a
-public release can create.
+superiority, or hosted performance. Even after a verified release, external
+validation and adoption gates remain evidence-led. The [validation
+ledger](docs/validation/spec-compliance-2026-09-01.md) keeps repository-controlled
+work separate from evidence that only real users can create.
 
 <!-- readme-section: faq -->
 ## FAQ and troubleshooting
@@ -230,9 +240,11 @@ dependency to be declared. Otherwise the finding remains explanatory and manual.
 field, the standalone file, then defaults. Non-default sources are reported in
 human-readable output.
 
+<!-- readme-state:production-faq:start -->
 **Can I use it in production CI today?** Treat this source checkout as an
 evaluation build. Wait for public npm, Release, provenance, checksum, and
 immutable Action-consumer evidence before depending on a released reference.
+<!-- readme-state:production-faq:end -->
 
 <!-- readme-section: navigation -->
 ## Go deeper

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,10 +16,12 @@
 
 ScriptSpect 会静态检查 npm 风格的 `package.json` scripts，并且不会运行它们。它识别在 `posix-sh`、Windows `cmd` 或可选 `powershell` 下含义不同的结构，精确指向相关 span，并只在安全条件得到证明后提供自动修复。
 
+<!-- readme-state:overview:start -->
 > [!IMPORTANT]
 > 本仓库目前是**预发布源码评估版**。npm package 与公开 Action tag 尚不存在；下面所有可复制步骤都特意固定到不可变 source commit。
 
 **[查看真实 demo](#修复前分析结果与修复后)** · **[从源码评估](#从源码评估evaluate-from-source-pre-release)** · **[GitHub Actions](#github-actions-预览pre-release)** · **[规则列表](docs/rules/README.md)**
+<!-- readme-state:overview:end -->
 
 <!-- readme-section: why -->
 ## 为什么值得使用
@@ -70,6 +72,7 @@ ScriptSpect 使用 target-specific 的结构化 parser，而不是用一组正�
 
 `--fix-dry-run` 只打印 patch 而不写入。`--fix` 使用 staged writes、写后重新分析与 recovery journal；它不会安装依赖或改写 lockfile。使用 `pnpm exec tsx tools/generate-readme-demo.ts` 可重新生成全部 demo assets。
 
+<!-- readme-state:evaluate:start -->
 <!-- readme-section: evaluate -->
 ## 从源码评估（Evaluate from source (pre-release)）
 
@@ -78,7 +81,7 @@ ScriptSpect 使用 target-specific 的结构化 parser，而不是用一组正�
 ```bash
 git clone https://github.com/Tom409114/scriptspect.git
 cd scriptspect
-git checkout 0898538abef5b054db6a20dc0ffe7fb9bb67e96b
+git checkout bf37b4132508c685a91cc16a9c0a3058c252502e
 corepack enable
 pnpm install --frozen-lockfile
 pnpm build
@@ -86,6 +89,7 @@ node dist/cli.mjs tests/fixtures/readme-demo
 ```
 
 这里特意还没有 `npx scriptspect` 快速开始。机器可读的 release state 见 [docs/readme-status.json](docs/readme-status.json)。
+<!-- readme-state:evaluate:end -->
 
 <!-- readme-section: cli -->
 ## CLI 快速参考
@@ -104,6 +108,7 @@ node dist/cli.mjs explain PS010
 
 显示过滤不会隐藏失败语义：任何配置为 `error` 的 finding 都会失败；未过滤 warning 总数会与 `--max-warnings` 比较。
 
+<!-- readme-state:action:start -->
 <!-- readme-section: action -->
 ## GitHub Actions 预览（pre-release）
 
@@ -124,7 +129,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Tom409114/scriptspect
-          ref: 0898538abef5b054db6a20dc0ffe7fb9bb67e96b
+          ref: bf37b4132508c685a91cc16a9c0a3058c252502e
           path: .scriptspect
           persist-credentials: false
       - uses: ./.scriptspect
@@ -133,12 +138,13 @@ jobs:
 ```
 
 Action 会先写入 annotations、job summary 以及名为 `exit-code`、`packages`、`scripts`、`errors`、`warnings`、`advisories` 的数字 outputs，再把 finding run 标记为失败。默认模式只读。
+<!-- readme-state:action:end -->
 
-**真实托管证据——不是模拟截图。** 在 `main` 的 `0898538` 上，公开的 [CI run #33449906358](https://github.com/Tom409114/scriptspect/actions/runs/33449906358) 使用 `uses: ./` 分别消费 clean 与 broken fixture。clean consumer 返回 `1 package · 1 script · 0 errors`；broken fixture 产生 2 条 check annotations，其中包括落在 `package.json` 上的 `PS010: scripts.clean`。
+**真实托管证据——不是模拟截图。** 在 `main` 的 `bf37b413` 上，公开的 [CI run #33467290054](https://github.com/Tom409114/scriptspect/actions/runs/33467290054) 使用 `uses: ./` 分别消费 clean 与 broken fixture。clean consumer 返回 `1 package · 1 script · 0 errors`；broken fixture 产生 2 条 check annotations，其中包括落在 `package.json` 上的 `PS010: scripts.clean`。
 
 ![根据真实托管 Action run 生成的验证卡片](docs/assets/demo/action.svg)
 
-[可选择的 Action 证据文本](docs/assets/demo/action.txt) · [提交进仓库的源证据](docs/validation/readme-action-evidence.json) · [打开托管 job](https://github.com/Tom409114/scriptspect/actions/runs/33449906358/job/99677215357)
+[可选择的 Action 证据文本](docs/assets/demo/action.txt) · [提交进仓库的源证据](docs/validation/readme-action-evidence.json) · [打开托管 job](https://github.com/Tom409114/scriptspect/actions/runs/33467290054/job/99729679961)
 
 <!-- readme-section: config -->
 ## 最小配置
@@ -163,6 +169,7 @@ Contracts：[config JSON Schema](schema/config.schema.json) · [JSON output Sche
 <!-- readme-section: support -->
 ## 支持范围与诚实边界
 
+<!-- readme-state:scope-table:start -->
 | 范围 | 当前源码评估行为 |
 | --- | --- |
 | Projects | 根 `package.json`，以及 npm/Yarn/Bun workspaces 与 `pnpm-workspace.yaml` |
@@ -171,9 +178,12 @@ Contracts：[config JSON Schema](schema/config.schema.json) · [JSON output Sche
 | Output | stylish terminal text、versioned JSON、GitHub annotations + summary |
 | Fixes | dry-run 以及可证明的 safe/conditional rewrites；ambiguous case 保持 manual |
 | Privacy | 离线分析；不执行 scripts；无 telemetry |
-| Release | pre-release；目前没有 npm package 或公开 Action reference |
+<!-- readme-state:scope-table:end -->
+<!-- readme-state:release-row:start -->
+**Release:** pre-release；目前没有 npm package 或公开 Action reference。
+<!-- readme-state:release-row:end -->
 
-本主页不宣称外部采用、测量精度、比较优势、hosted performance 或 release gate 已完成。[validation ledger](docs/validation/spec-compliance-2026-09-01.md) 会把仓库内可以完成的工程工作，与只有真实用户和公开 release 才能形成的 evidence 分开。
+本主页不宣称外部采用、测量精度、比较优势或 hosted performance。即使 verified release 完成，外部验证与采用门仍必须由真实 evidence 驱动。[validation ledger](docs/validation/spec-compliance-2026-09-01.md) 会把仓库内可以完成的工程工作，与只有真实用户才能形成的 evidence 分开。
 
 <!-- readme-section: faq -->
 ## 常见问题与故障排查
@@ -186,7 +196,9 @@ Contracts：[config JSON Schema](schema/config.schema.json) · [JSON output Sche
 
 **最终使用了哪个 config？** 显式 `--config` 优先，其次是 `package.json` 字段、standalone file，最后是 defaults。人类可读输出会报告非默认 source。
 
+<!-- readme-state:production-faq:start -->
 **现在能在 production CI 使用吗？** 请把这份 source checkout 当作 evaluation build。等待公开 npm、Release、provenance、checksum 与 immutable Action-consumer evidence 齐全后，再依赖 released reference。
+<!-- readme-state:production-faq:end -->
 
 <!-- readme-section: navigation -->
 ## 深入了解

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,8 @@ The GitHub homepage is available in [English](../README.md) and [Simplified Chin
 
 ## Project status and governance
 
-- [Pre-release homepage status](readme-status.json)
+- [Homepage release status](readme-status.json)
+- [Published-homepage handoff](release-readme.md)
 - [Validation audit](validation/spec-compliance-2026-09-01.md)
 - [Corpus report](validation/corpus-2026-08.md)
 - [Roadmap](roadmap.md)

--- a/docs/assets/demo/action.svg
+++ b/docs/assets/demo/action.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="480" viewBox="0 0 1100 480" role="img" aria-labelledby="title desc" data-run-id="33449906358">
+<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="480" viewBox="0 0 1100 480" role="img" aria-labelledby="title desc" data-run-id="33467290054">
   <title id="title">Hosted Action evidence</title>
-  <desc id="desc">Public CI run 33449906358 passed at source commit 0898538a. A clean consumer returned zero errors, while the broken fixture produced 2 annotations including PS010: scripts.clean.</desc>
+  <desc id="desc">Public CI run 33467290054 passed at source commit bf37b413. A clean consumer returned zero errors, while the broken fixture produced 2 annotations including PS010: scripts.clean.</desc>
   <defs>
     <linearGradient id="action-bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#090d1a"/>
@@ -25,7 +25,7 @@
   <rect x="1" y="1" width="1098" height="478" rx="21" fill="none" stroke="#7c8db5" stroke-opacity="0.28"/>
   <rect x="52" y="46" width="9" height="42" rx="4.5" fill="url(#action-line)"/>
   <text x="82" y="70" class="sans" fill="#f8fbff" font-size="30" font-weight="770">Hosted Action evidence</text>
-  <text x="82" y="94" class="mono muted" font-size="14">main @ 0898538a · CI run #33449906358</text>
+  <text x="82" y="94" class="mono muted" font-size="14">main @ bf37b413 · CI run #33467290054</text>
   <rect x="866" y="50" width="182" height="38" rx="19" fill="#10372f" stroke="#34d399" stroke-opacity="0.65"/>
   <circle cx="890" cy="69" r="7" fill="#34d399"/>
   <text x="908" y="75" class="sans" fill="#a7f3d0" font-size="16" font-weight="720">VERIFIED · PASS</text>

--- a/docs/assets/demo/action.txt
+++ b/docs/assets/demo/action.txt
@@ -1,7 +1,7 @@
 ScriptSpect hosted Action evidence
-workflow run: 33449906358 (success)
-workflow URL: https://github.com/Tom409114/scriptspect/actions/runs/33449906358
-source commit: 0898538abef5b054db6a20dc0ffe7fb9bb67e96b
+workflow run: 33467290054 (success)
+workflow URL: https://github.com/Tom409114/scriptspect/actions/runs/33467290054
+source commit: bf37b4132508c685a91cc16a9c0a3058c252502e
 clean consumer: exit 0 · 1 package · 1 script · 0 errors
 broken fixture: 2 annotations
 - Action failure contract — .github: scriptspect action failed

--- a/docs/assets/demo/terminal.svg
+++ b/docs/assets/demo/terminal.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="1100" height="930" viewBox="0 0 1100 930" role="img" aria-labelledby="title desc">
-  <title id="title">ScriptSpect pre-release demo output</title>
+  <title id="title">ScriptSpect demo output</title>
   <desc id="desc">Terminal output from checking the README demo fixture. The selectable text version is available beside this image.</desc>
   <style>.terminal { fill: #0d1117; } .bar { fill: #161b22; } .terminal-line { fill: #c9d1d9; font: 16px ui-monospace, SFMono-Regular, Consolas, monospace; white-space: pre; } .terminal-command { fill: #7ee787; } .terminal-section { fill: #79c0ff; font-weight: 600; } .terminal-error { fill: #ff7b72; font-weight: 600; } .terminal-advisory { fill: #d29922; font-weight: 600; } .terminal-summary { fill: #8b949e; }</style>
   <rect class="terminal" width="100%" height="100%" rx="12"/>

--- a/docs/readme-status.json
+++ b/docs/readme-status.json
@@ -3,7 +3,7 @@
   "releaseState": "pre-release",
   "packageName": "scriptspect",
   "packageVersion": "0.0.0",
-  "sourceCommit": "0898538abef5b054db6a20dc0ffe7fb9bb67e96b",
+  "sourceCommit": "bf37b4132508c685a91cc16a9c0a3058c252502e",
   "nodeMajor": 22,
   "repository": "https://github.com/Tom409114/scriptspect"
 }

--- a/docs/release-readme.md
+++ b/docs/release-readme.md
@@ -1,0 +1,55 @@
+# Published-homepage handoff
+
+The homepage must remain in `pre-release` state until the release workflow has
+finished npm publication, provenance verification, public Release verification,
+floating-alias verification, and the terminal `consumed` release state.
+
+The transition is deliberately a second pull request. Do not include it in the
+release-please PR: the README can only cite public evidence that exists after the
+release commit has been published and verified.
+
+## Prepare the evidence PR
+
+Set the exact released version, resolve its immutable tag locally, and provide a
+GitHub token for read-only evidence checks:
+
+```bash
+VERSION=0.1.0
+RELEASE_COMMIT="$(git rev-parse "v${VERSION}^{commit}")"
+export VERSION RELEASE_COMMIT
+export GITHUB_TOKEN="$(gh auth token)"
+```
+
+1. Confirm the exact `npm-publish.yml` run succeeded. Download its
+   `readme-release-receipt-v$VERSION` artifact.
+2. Put the single receipt at
+   `docs/validation/releases/v$VERSION/readme-release-receipt.json` without
+   editing it.
+3. Update `SECURITY.md` under **Supported versions** so it names the now-public
+   exact release and `main`; remove the obsolete “No npm release has been
+   published yet” sentence. Keep the post-release artifact policy in
+   `MAINTAINERS.md`: it remains the rule for every later release.
+4. Generate the status manifest from the immutable release commit and receipt:
+
+   ```bash
+   pnpm exec tsx tools/generate-readme-status.ts "$RELEASE_COMMIT" \
+     --published \
+     --receipt "docs/validation/releases/v$VERSION/readme-release-receipt.json"
+   ```
+
+5. Render both homepages and verify the public evidence chain:
+
+   ```bash
+   pnpm exec tsx tools/render-readme-state.ts
+   pnpm exec tsx tools/verify-readme-release-evidence.ts
+   pnpm exec tsx tools/check-readme-parity.ts
+   pnpm exec vitest run tests/docs
+   ```
+
+6. Open a protected documentation PR. Its Generated-files CI job repeats the
+   public GitHub, Release-asset, npm-integrity, and Action-alias checks. Merge only
+   after every required check passes.
+
+The receipt records IDs and digests, not just mutable names or download URLs. A
+deleted-and-reuploaded asset, a non-terminal release intent, a moved tag, an npm
+integrity mismatch, or a stale floating alias makes verification fail closed.

--- a/docs/validation/readme-action-evidence.json
+++ b/docs/validation/readme-action-evidence.json
@@ -1,17 +1,17 @@
 {
   "schemaVersion": 1,
-  "capturedAt": "2026-08-31T23:17:14Z",
-  "sourceCommit": "0898538abef5b054db6a20dc0ffe7fb9bb67e96b",
+  "capturedAt": "2026-09-01T03:46:10Z",
+  "sourceCommit": "bf37b4132508c685a91cc16a9c0a3058c252502e",
   "workflowRun": {
-    "id": 33449906358,
+    "id": 33467290054,
     "name": "CI",
-    "url": "https://github.com/Tom409114/scriptspect/actions/runs/33449906358",
+    "url": "https://github.com/Tom409114/scriptspect/actions/runs/33467290054",
     "conclusion": "success"
   },
   "checkRun": {
-    "id": 99677215357,
+    "id": 99729679961,
     "name": "Bundled Action consumer",
-    "url": "https://github.com/Tom409114/scriptspect/actions/runs/33449906358/job/99677215357",
+    "url": "https://github.com/Tom409114/scriptspect/actions/runs/33467290054/job/99729679961",
     "annotationCount": 2,
     "summarySha256": "6f404488da1babb4ba885e873c5187e4e1c5179a2c868bc5324a2e3b8c71c404"
   },

--- a/tests/docs/npm-readme.test.ts
+++ b/tests/docs/npm-readme.test.ts
@@ -1,0 +1,112 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = resolve(import.meta.dirname, '../..');
+const tsx = resolve(root, 'node_modules/tsx/dist/cli.mjs');
+const generator = resolve(root, 'tools/release/generate-package-readmes.mjs');
+const sourceCommit = 'a'.repeat(40);
+
+function generate(version: string) {
+  const directory = mkdtempSync(join(tmpdir(), 'scriptspect-npm-readme-'));
+  const english = join(directory, 'README.md');
+  const chinese = join(directory, 'README.zh-CN.md');
+  const result = spawnSync(
+    process.execPath,
+    [
+      tsx,
+      generator,
+      '--version',
+      version,
+      '--source-commit',
+      sourceCommit,
+      '--channel',
+      version.includes('-bootstrap.') ? 'bootstrap' : 'stable',
+      '--english',
+      english,
+      '--chinese',
+      chinese,
+    ],
+    { cwd: root, encoding: 'utf8' },
+  );
+  return { directory, english, chinese, result };
+}
+
+describe('npm-only bilingual README generator', () => {
+  it('generates attractive exact-version stable-package instructions without pre-release claims', () => {
+    const generated = generate('0.1.0');
+    try {
+      expect(generated.result.status, generated.result.stderr).toBe(0);
+      const english = readFileSync(generated.english, 'utf8');
+      const chinese = readFileSync(generated.chinese, 'utf8');
+      for (const readme of [english, chinese]) {
+        expect(readme).toContain('npx --yes scriptspect@0.1.0 .');
+        expect(readme).toContain('pnpm dlx scriptspect@0.1.0 .');
+        expect(readme).toContain(`raw.githubusercontent.com/Tom409114/scriptspect/${sourceCommit}`);
+        expect(readme).toContain('docs/assets/demo/terminal.svg');
+        expect(readme).not.toContain('npm package and public Action tag do not exist yet');
+        expect(readme).not.toContain('npm package 与公开 Action tag 尚不存在');
+        expect(readme).not.toContain('pre-release source evaluation');
+        expect(readme).not.toContain('/SECURITY.md');
+        expect(readme).toContain('/security/advisories/new');
+      }
+      expect(english).toContain('uses: Tom409114/scriptspect@v0.1.0');
+      expect(chinese).toContain('uses: Tom409114/scriptspect@v0.1.0');
+      expect(english).toContain('Before, result, and after');
+      expect(chinese).toContain('修复前、分析结果与修复后');
+    } finally {
+      rmSync(generated.directory, { recursive: true, force: true });
+    }
+  });
+
+  it('labels bootstrap packages as prerelease ownership artifacts without a stable Action tag', () => {
+    const generated = generate('0.0.0-bootstrap.7');
+    try {
+      expect(generated.result.status, generated.result.stderr).toBe(0);
+      for (const path of [generated.english, generated.chinese]) {
+        const readme = readFileSync(path, 'utf8');
+        expect(readme).toContain('scriptspect@0.0.0-bootstrap.7');
+        expect(readme).toContain('bootstrap');
+        expect(readme).toContain('/.github/workflows/npm-bootstrap.yml');
+        expect(readme).not.toContain('uses: Tom409114/scriptspect@v0.0.0-bootstrap.7');
+      }
+    } finally {
+      rmSync(generated.directory, { recursive: true, force: true });
+    }
+  });
+
+  it('links the bootstrap policy to a source-controlled file that exists', () => {
+    expect(() =>
+      readFileSync(resolve(root, '.github/workflows/npm-bootstrap.yml'), 'utf8'),
+    ).not.toThrow();
+  });
+
+  it('fails closed for an invalid version or source commit', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'scriptspect-npm-readme-invalid-'));
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [
+          tsx,
+          generator,
+          '--version',
+          'latest',
+          '--source-commit',
+          'main',
+          '--channel',
+          'stable',
+          '--english',
+          join(directory, 'README.md'),
+          '--chinese',
+          join(directory, 'README.zh-CN.md'),
+        ],
+        { cwd: root, encoding: 'utf8' },
+      );
+      expect(result.status).not.toBe(0);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/docs/public-claims.test.ts
+++ b/tests/docs/public-claims.test.ts
@@ -47,13 +47,26 @@ describe('public project claims', () => {
     const security = read('SECURITY.md');
     const maintainers = read('MAINTAINERS.md');
     const changelog = read('CHANGELOG.md');
+    const readmeStatus = JSON.parse(read('docs/readme-status.json')) as {
+      releaseState: 'pre-release' | 'published';
+      packageVersion: string;
+    };
     const releaseManifest = JSON.parse(read('.release-please-manifest.json')) as Record<
       string,
       string
     >;
 
-    expect(security).toContain('No npm release has been published yet');
-    expect(maintainers).toContain('After the first release');
+    if (readmeStatus.releaseState === 'pre-release') {
+      expect(security).toContain('No npm release has been published yet');
+    } else {
+      expect(security).not.toContain('No npm release has been published yet');
+      expect(security).not.toContain('not published yet');
+      expect(security).not.toContain('main` (pre-release)');
+      expect(security).toContain(`\`${readmeStatus.packageVersion}\``);
+    }
+    expect(maintainers).toContain(
+      'After the first release, each successful release must publish the same tarball',
+    );
     if (releaseManifest['.'] === '0.0.0') {
       expect(changelog).toBe('');
     } else {

--- a/tests/docs/readme-homepage.test.ts
+++ b/tests/docs/readme-homepage.test.ts
@@ -1,8 +1,18 @@
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { existsSync, readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { canonicalJsonDigest } from '../../tools/release/release-state.mjs';
 
 const root = resolve(import.meta.dirname, '../..');
 const read = (path: string): string => readFileSync(resolve(root, path), 'utf8');
@@ -15,7 +25,7 @@ const runTool = (tool: string): string =>
 const fencedBlocks = (markdown: string): string[] =>
   [...markdown.matchAll(/```[^\n]*\n([\s\S]*?)```/g)].map((match) => match[1] ?? '');
 
-describe('bilingual pre-release homepage', () => {
+describe('bilingual homepage', () => {
   it('uses responsive, accessible, self-contained brand heroes and only truthful badges', () => {
     const english = read('README.md');
     const chinese = read('README.zh-CN.md');
@@ -40,7 +50,14 @@ describe('bilingual pre-release homepage', () => {
     }
   });
 
-  it('does not present an unpublished package or Action release as usable', () => {
+  it('keeps generated release status outside the capability table', () => {
+    for (const homepage of [read('README.md'), read('README.zh-CN.md')]) {
+      expect(homepage).not.toMatch(/<!-- readme-state:release-row:start -->\n\| Release \|/u);
+      expect(homepage).toMatch(/<!-- readme-state:release-row:start -->\n\*\*Release:\*\*/u);
+    }
+  });
+
+  it('presents only commands supported by the recorded release state', () => {
     const english = read('README.md');
     const chinese = read('README.zh-CN.md');
     const status = JSON.parse(read('docs/readme-status.json')) as {
@@ -48,20 +65,23 @@ describe('bilingual pre-release homepage', () => {
       sourceCommit: string;
     };
 
-    expect(status.releaseState).toBe('pre-release');
-    expect(status.sourceCommit).toBe('0898538abef5b054db6a20dc0ffe7fb9bb67e96b');
+    expect(status.sourceCommit).toMatch(/^[0-9a-f]{40}$/u);
     for (const homepage of [english, chinese]) {
-      expect(homepage).toContain('Evaluate from source (pre-release)');
-      expect(fencedBlocks(homepage).some((block) => /\bnpx\s+scriptspect\b/.test(block))).toBe(
-        false,
-      );
-      expect(
-        fencedBlocks(homepage).some((block) => /Tom409114\/scriptspect@v0\.1\b/.test(block)),
-      ).toBe(false);
       expect(homepage).not.toMatch(/All milestones.*merged/i);
       expect(homepage).not.toMatch(/production[- ]ready/i);
-      expect(homepage).toContain(`git checkout ${status.sourceCommit}`);
-      expect(homepage).toContain(`ref: ${status.sourceCommit}`);
+      if (status.releaseState === 'pre-release') {
+        expect(homepage).toContain('Evaluate from source (pre-release)');
+        expect(
+          fencedBlocks(homepage).some((block) =>
+            /\b(?:npx\s+(?:--yes\s+)?scriptspect|pnpm\s+dlx\s+scriptspect)@?/u.test(block),
+          ),
+        ).toBe(false);
+        expect(
+          fencedBlocks(homepage).some((block) => /Tom409114\/scriptspect@v0\.1\b/.test(block)),
+        ).toBe(false);
+        expect(homepage).toContain(`git checkout ${status.sourceCommit}`);
+        expect(homepage).toContain(`ref: ${status.sourceCommit}`);
+      }
     }
   });
 
@@ -76,16 +96,16 @@ describe('bilingual pre-release homepage', () => {
       annotations: Array<{ title: string; displayTitle?: string; message: string }>;
     };
 
-    expect(evidence.sourceCommit).toBe('0898538abef5b054db6a20dc0ffe7fb9bb67e96b');
+    expect(evidence.sourceCommit).toBe('bf37b4132508c685a91cc16a9c0a3058c252502e');
     expect(evidence.workflowRun).toEqual(
       expect.objectContaining({
-        id: 33449906358,
+        id: 33467290054,
         conclusion: 'success',
-        url: 'https://github.com/Tom409114/scriptspect/actions/runs/33449906358',
+        url: 'https://github.com/Tom409114/scriptspect/actions/runs/33467290054',
       }),
     );
     expect(evidence.checkRun).toEqual(
-      expect.objectContaining({ id: 99677215357, annotationCount: 2 }),
+      expect.objectContaining({ id: 99729679961, annotationCount: 2 }),
     );
     expect(evidence.cleanConsumer).toEqual(
       expect.objectContaining({ exitCode: 0, packages: 1, scripts: 1, errors: 0 }),
@@ -113,8 +133,8 @@ describe('bilingual pre-release homepage', () => {
       expect(homepage).toContain('docs/assets/demo/action.txt');
       expect(homepage).toContain('docs/validation/readme-action-evidence.json');
       expect(homepage).toContain(evidence.workflowRun.url);
-      expect(homepage).toContain('33449906358');
-      expect(homepage).toContain('0898538');
+      expect(homepage).toContain('33467290054');
+      expect(homepage).toContain('bf37b413');
     }
   });
 
@@ -129,6 +149,206 @@ describe('bilingual pre-release homepage', () => {
 
   it('keeps stable commands, URLs, rule IDs, sections, and assets in parity', () => {
     expect(runTool('tools/check-readme-parity.ts')).toContain('README parity check passed');
+  });
+
+  it('renders a published bilingual homepage from an explicit verified release state', () => {
+    const temporaryRoot = mkdtempSync(join(tmpdir(), 'scriptspect-readme-state-'));
+    const englishPath = join(temporaryRoot, 'README.md');
+    const chinesePath = join(temporaryRoot, 'README.zh-CN.md');
+    const statusPath = join(temporaryRoot, 'readme-status.json');
+    const receiptDirectory = join(temporaryRoot, 'validation', 'releases', 'v0.1.0');
+    const receiptPath = join(receiptDirectory, 'readme-release-receipt.json');
+    copyFileSync(resolve(root, 'README.md'), englishPath);
+    copyFileSync(resolve(root, 'README.zh-CN.md'), chinesePath);
+    const finalVerification = {
+      schemaVersion: 'scriptspect-final-verification/v1',
+      intentId: 'scriptspect-release-intent:62:bf37b4132508c685a91cc16a9c0a3058c252502e',
+      version: '0.1.0',
+      tag: 'v0.1.0',
+      commit: 'bf37b4132508c685a91cc16a9c0a3058c252502e',
+      releaseId: 123456,
+      candidateManifestDigest: 'a'.repeat(64),
+      releaseManifestDigest: 'b'.repeat(64),
+      candidateNpmSRI: `sha512-${Buffer.alloc(64, 1).toString('base64')}`,
+      registryNpmSRI: `sha512-${Buffer.alloc(64, 1).toString('base64')}`,
+      provenanceDigest: 'c'.repeat(64),
+      aliases: [
+        { name: 'v0.1', target: 'bf37b4132508c685a91cc16a9c0a3058c252502e' },
+        { name: 'v0', target: 'bf37b4132508c685a91cc16a9c0a3058c252502e' },
+      ],
+    };
+    const receipt = {
+      schemaVersion: 'scriptspect-readme-release-receipt/v1',
+      repository: 'https://github.com/Tom409114/scriptspect',
+      intentCheckRunId: 123456789,
+      finalVerificationAssetId: 987654321,
+      finalVerificationDigest: canonicalJsonDigest(finalVerification),
+      publishRunId: 123456790,
+      finalVerification,
+    };
+    mkdirSync(receiptDirectory, { recursive: true });
+    writeFileSync(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`);
+    writeFileSync(
+      statusPath,
+      `${JSON.stringify(
+        {
+          schemaVersion: 1,
+          releaseState: 'published',
+          packageName: 'scriptspect',
+          packageVersion: '0.1.0',
+          sourceCommit: 'bf37b4132508c685a91cc16a9c0a3058c252502e',
+          nodeMajor: 22,
+          repository: 'https://github.com/Tom409114/scriptspect',
+          releaseEvidence: {
+            receiptPath: 'validation/releases/v0.1.0/readme-release-receipt.json',
+            digest: canonicalJsonDigest(receipt),
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [
+          resolve(root, 'node_modules/tsx/dist/cli.mjs'),
+          resolve(root, 'tools/render-readme-state.ts'),
+          '--status',
+          statusPath,
+          '--english',
+          englishPath,
+          '--chinese',
+          chinesePath,
+        ],
+        { cwd: root, encoding: 'utf8' },
+      );
+      expect(result.status, result.stderr).toBe(0);
+
+      const english = readFileSync(englishPath, 'utf8');
+      const chinese = readFileSync(chinesePath, 'utf8');
+      for (const homepage of [english, chinese]) {
+        expect(homepage).toContain('npx --yes scriptspect@0.1.0 .');
+        expect(homepage).toContain('pnpm dlx scriptspect@0.1.0 .');
+        expect(homepage).toContain('uses: Tom409114/scriptspect@v0.1.0');
+        expect(homepage).toContain('bf37b4132508c685a91cc16a9c0a3058c252502e');
+        expect(homepage).not.toContain('Evaluate from source (pre-release)');
+      }
+      expect(english).toContain('Verified release');
+      expect(english).not.toContain('Latest verified release');
+      expect(english).not.toContain('npm package and public Action tag do not exist yet');
+      expect(english).toContain('| Area | Current behavior |');
+      expect(english).not.toContain('Current source-evaluation behavior');
+      expect(chinese).toContain('已验证 release');
+      expect(chinese).not.toContain('最新已验证 release');
+      expect(chinese).not.toContain('npm package 与公开 Action tag 尚不存在');
+      expect(chinese).toContain('| 范围 | 当前行为 |');
+      expect(chinese).not.toContain('当前源码评估行为');
+
+      const pristineParity = spawnSync(
+        process.execPath,
+        [
+          resolve(root, 'node_modules/tsx/dist/cli.mjs'),
+          resolve(root, 'tools/check-readme-parity.ts'),
+          '--status',
+          statusPath,
+          '--english',
+          englishPath,
+          '--chinese',
+          chinesePath,
+        ],
+        { cwd: root, encoding: 'utf8' },
+      );
+      expect(pristineParity.status, pristineParity.stderr).toBe(0);
+      expect(pristineParity.stdout).toContain('README parity check passed');
+
+      writeFileSync(englishPath, english.replace('scriptspect@0.1.0 .', 'scriptspect@9.9.9 .'));
+      writeFileSync(chinesePath, chinese.replace('scriptspect@0.1.0 .', 'scriptspect@9.9.9 .'));
+      const staleCheck = spawnSync(
+        process.execPath,
+        [
+          resolve(root, 'node_modules/tsx/dist/cli.mjs'),
+          resolve(root, 'tools/check-readme-parity.ts'),
+          '--status',
+          statusPath,
+          '--english',
+          englishPath,
+          '--chinese',
+          chinesePath,
+        ],
+        { cwd: root, encoding: 'utf8' },
+      );
+      expect(staleCheck.status).not.toBe(0);
+      expect(staleCheck.stderr).toContain('homepage is stale for published');
+    } finally {
+      rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses a published homepage without terminal release evidence', () => {
+    const temporaryRoot = mkdtempSync(join(tmpdir(), 'scriptspect-readme-unverified-'));
+    const englishPath = join(temporaryRoot, 'README.md');
+    const chinesePath = join(temporaryRoot, 'README.zh-CN.md');
+    const statusPath = join(temporaryRoot, 'readme-status.json');
+    copyFileSync(resolve(root, 'README.md'), englishPath);
+    copyFileSync(resolve(root, 'README.zh-CN.md'), chinesePath);
+    writeFileSync(
+      statusPath,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        releaseState: 'published',
+        packageName: 'scriptspect',
+        packageVersion: '0.1.0',
+        sourceCommit: 'bf37b4132508c685a91cc16a9c0a3058c252502e',
+        nodeMajor: 22,
+        repository: 'https://github.com/Tom409114/scriptspect',
+      })}\n`,
+    );
+
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [
+          resolve(root, 'node_modules/tsx/dist/cli.mjs'),
+          resolve(root, 'tools/render-readme-state.ts'),
+          '--status',
+          statusPath,
+          '--english',
+          englishPath,
+          '--chinese',
+          chinesePath,
+        ],
+        { cwd: root, encoding: 'utf8' },
+      );
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain('terminal release evidence');
+    } finally {
+      rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to mark the homepage published from a version bump alone', () => {
+    const before = read('docs/readme-status.json');
+    const version = (JSON.parse(read('package.json')) as { version: string }).version;
+    const result = spawnSync(
+      process.execPath,
+      [
+        resolve(root, 'node_modules/tsx/dist/cli.mjs'),
+        resolve(root, 'tools/generate-readme-status.ts'),
+        'HEAD',
+        '--published',
+      ],
+      { cwd: root, encoding: 'utf8' },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      version === '0.0.0'
+        ? 'published README state requires a nonzero released version'
+        : 'published README state requires --receipt terminal evidence',
+    );
+    expect(read('docs/readme-status.json')).toBe(before);
   });
 });
 
@@ -164,6 +384,8 @@ describe('README demo artifacts', () => {
     expect(terminal).toContain('exit code: 1');
     const terminalSvg = read('docs/assets/demo/terminal.svg');
     expect(terminalSvg).toMatch(/<svg[^>]+role="img"[^>]+aria-labelledby=/);
+    expect(terminalSvg).toContain('<title id="title">ScriptSpect demo output</title>');
+    expect(terminalSvg).not.toContain('pre-release demo output');
     expect(terminalSvg).toContain('class="terminal-line terminal-error"');
     expect(terminalSvg).toContain('class="terminal-line terminal-advisory"');
     expect(terminalSvg).toContain('class="terminal-line terminal-command"');
@@ -173,14 +395,14 @@ describe('README demo artifacts', () => {
     expect(renderedColumnCounts.length).toBeGreaterThan(terminal.split('\n').length);
     expect(Math.max(...renderedColumnCounts)).toBeLessThanOrEqual(104);
     const actionText = read('docs/assets/demo/action.txt');
-    expect(actionText).toContain('workflow run: 33449906358 (success)');
-    expect(actionText).toContain('source commit: 0898538abef5b054db6a20dc0ffe7fb9bb67e96b');
+    expect(actionText).toContain('workflow run: 33467290054 (success)');
+    expect(actionText).toContain('source commit: bf37b4132508c685a91cc16a9c0a3058c252502e');
     expect(actionText).toContain('broken fixture: 2 annotations');
     expect(actionText).toContain('PS010: scripts.clean');
     const actionSvg = read('docs/assets/demo/action.svg');
     expect(actionSvg).toMatch(/<svg[^>]+role="img"[^>]+aria-labelledby=/);
     expect(actionSvg).toContain('Hosted Action evidence');
-    expect(actionSvg).toContain('data-run-id="33449906358"');
+    expect(actionSvg).toContain('data-run-id="33467290054"');
     expect(actionSvg).not.toMatch(/<script|(?:href|src)=["']https?:\/\//iu);
     const patch = read('docs/assets/demo/fix.patch');
     expect(patch).toContain('--- a/package.json');

--- a/tests/docs/readme-release-evidence-remote.test.ts
+++ b/tests/docs/readme-release-evidence-remote.test.ts
@@ -1,0 +1,574 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { canonicalJsonDigest } from '../../tools/release/release-state.mjs';
+import { verifyReadmeReleaseEvidence } from '../../tools/verify-readme-release-evidence.js';
+
+const sourceCommit = 'bf37b4132508c685a91cc16a9c0a3058c252502e';
+const intentCheckRunId = 123456789;
+const finalVerificationAssetId = 234567890;
+const publishRunId = 345678901;
+const npmSRI =
+  'sha512-AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ==';
+
+const finalVerification = {
+  schemaVersion: 'scriptspect-final-verification/v1',
+  intentId: 'release-intent-0.1.0',
+  version: '0.1.0',
+  tag: 'v0.1.0',
+  commit: sourceCommit,
+  releaseId: 123456,
+  candidateManifestDigest: 'a'.repeat(64),
+  releaseManifestDigest: 'b'.repeat(64),
+  candidateNpmSRI: npmSRI,
+  registryNpmSRI: npmSRI,
+  provenanceDigest: 'c'.repeat(64),
+  aliases: [
+    { name: 'v0.1', target: sourceCommit },
+    { name: 'v0', target: sourceCommit },
+  ],
+} as const;
+
+const finalVerificationDigest = canonicalJsonDigest(finalVerification);
+
+const immutableAssets = [
+  { name: 'scriptspect-0.1.0.tgz', assetId: 234567881, sha256: 'd'.repeat(64) },
+  { name: 'SHA256SUMS', assetId: 234567882, sha256: 'e'.repeat(64) },
+  { name: 'candidate-manifest.json', assetId: 234567883, sha256: 'f'.repeat(64) },
+  {
+    name: 'release-manifest.json',
+    assetId: 234567884,
+    sha256: finalVerification.releaseManifestDigest,
+  },
+] as const;
+
+const consumedState = {
+  schemaVersion: 'scriptspect-release-state/v1',
+  revision: 8,
+  state: 'consumed',
+  intent: {
+    schemaVersion: 'scriptspect-release-intent/v1',
+    intentId: finalVerification.intentId,
+    prNumber: 62,
+    mergeCommitSha: sourceCommit,
+    version: finalVerification.version,
+    tag: finalVerification.tag,
+    packageManifestHash: '1'.repeat(64),
+    changelogHash: '2'.repeat(64),
+    releasePleaseManifestHash: '3'.repeat(64),
+    releasePrActor: 'googleapis-release-please[bot]',
+    releasePrHead: 'googleapis:release-please--branches--main',
+    releasePrHeadRepo: 'Tom409114/scriptspect',
+    releasePrHeadSha: '4'.repeat(40),
+  },
+  retainedCandidate: {
+    runId: 345678890,
+    artifactId: 234567800,
+    artifactDigest: '5'.repeat(64),
+    candidateManifestDigest: finalVerification.candidateManifestDigest,
+    npmSRI,
+  },
+  stagedDraft: {
+    releaseId: finalVerification.releaseId,
+    assets: immutableAssets,
+    releaseManifestDigest: finalVerification.releaseManifestDigest,
+  },
+  npmPublished: {
+    publishedVersion: finalVerification.version,
+    npmSRI,
+    publishRunId,
+  },
+  npmVerified: {
+    registryNpmSRI: npmSRI,
+    registryManifestDigest: '6'.repeat(64),
+    provenanceDigest: finalVerification.provenanceDigest,
+  },
+  aliasPlan: {
+    version: finalVerification.version,
+    commit: sourceCommit,
+    aliases: [
+      { name: 'v0.1', previousTarget: null, target: sourceCommit },
+      { name: 'v0', previousTarget: null, target: sourceCommit },
+    ],
+  },
+  aliasesVerified: {
+    aliases: [
+      { name: 'v0.1', previousTarget: null, target: sourceCommit },
+      { name: 'v0', previousTarget: null, target: sourceCommit },
+    ],
+  },
+  finalPlanned: { finalVerificationDigest },
+  consumed: { finalVerificationDigest, finalVerificationAssetId },
+} as const;
+
+const receipt = {
+  schemaVersion: 'scriptspect-readme-release-receipt/v1',
+  repository: 'https://github.com/Tom409114/scriptspect',
+  intentCheckRunId,
+  finalVerificationAssetId,
+  finalVerificationDigest,
+  publishRunId,
+  finalVerification,
+} as const;
+
+type RemoteFixtureOverrides = {
+  checkRun?: unknown;
+  release?: unknown;
+  finalAssetBytes?: string;
+  npmMetadata?: unknown;
+  refs?: Record<string, unknown>;
+};
+
+function checkRunFor(state: unknown = consumedState): unknown {
+  return {
+    id: intentCheckRunId,
+    name: 'release-intent',
+    status: 'completed',
+    conclusion: 'success',
+    head_sha: sourceCommit,
+    external_id: finalVerification.intentId,
+    app: { slug: 'github-actions' },
+    output: {
+      title: 'Consumed release intent',
+      summary: 'Final verification is exact and idempotent',
+      text: JSON.stringify(state),
+    },
+  };
+}
+
+function releaseFixture(): unknown {
+  return {
+    id: finalVerification.releaseId,
+    tag_name: finalVerification.tag,
+    target_commitish: sourceCommit,
+    draft: false,
+    prerelease: false,
+    assets: [
+      ...immutableAssets.map((asset) => ({
+        id: asset.assetId,
+        name: asset.name,
+        digest: `sha256:${asset.sha256}`,
+      })),
+      {
+        id: finalVerificationAssetId,
+        name: 'final-verification.json',
+        digest: `sha256:${finalVerificationDigest}`,
+      },
+    ],
+  };
+}
+
+function refFixtures(): Record<string, unknown> {
+  return Object.fromEntries(
+    [finalVerification.tag, 'v0.1', 'v0'].map((tag) => [
+      tag,
+      { ref: `refs/tags/${tag}`, object: { type: 'commit', sha: sourceCommit } },
+    ]),
+  );
+}
+
+const temporaryRoots: string[] = [];
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'number') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((entry) => canonicalJson(entry)).join(',')}]`;
+  const object = value as Record<string, unknown>;
+  return `{${Object.keys(object)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(object[key])}`)
+    .join(',')}}`;
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function writeLocalEvidence(statusOverrides: Record<string, unknown> = {}): {
+  repositoryRoot: string;
+  statusPath: string;
+} {
+  const repositoryRoot = mkdtempSync(join(tmpdir(), 'scriptspect-readme-remote-'));
+  temporaryRoots.push(repositoryRoot);
+  const statusPath = join(repositoryRoot, 'docs', 'readme-status.json');
+  const receiptDirectory = join(repositoryRoot, 'docs', 'validation', 'releases', 'v0.1.0');
+  mkdirSync(receiptDirectory, { recursive: true });
+  writeFileSync(
+    join(receiptDirectory, 'readme-release-receipt.json'),
+    `${JSON.stringify(receipt, null, 2)}\n`,
+  );
+  writeFileSync(
+    statusPath,
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        releaseState: 'published',
+        packageName: 'scriptspect',
+        packageVersion: finalVerification.version,
+        sourceCommit,
+        nodeMajor: 22,
+        repository: receipt.repository,
+        releaseEvidence: {
+          receiptPath: 'validation/releases/v0.1.0/readme-release-receipt.json',
+          digest: canonicalJsonDigest(receipt),
+        },
+        ...statusOverrides,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  return { repositoryRoot, statusPath };
+}
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function remoteFetch(overrides: RemoteFixtureOverrides = {}): typeof fetch {
+  const apiRoot = 'https://api.github.com/repos/Tom409114/scriptspect';
+  const checkRun = overrides.checkRun ?? checkRunFor();
+  const release = overrides.release ?? releaseFixture();
+  const refs = overrides.refs ?? refFixtures();
+  const npmMetadata =
+    overrides.npmMetadata ??
+    ({
+      name: 'scriptspect',
+      version: finalVerification.version,
+      dist: {
+        integrity: npmSRI,
+        tarball: 'https://registry.npmjs.org/scriptspect/-/scriptspect-0.1.0.tgz',
+      },
+    } as const);
+  const finalAssetBytes = overrides.finalAssetBytes ?? `${canonicalJson(finalVerification)}\n`;
+
+  return async (input, init) => {
+    const url = input instanceof URL ? input.href : typeof input === 'string' ? input : input.url;
+    if (url.startsWith(apiRoot)) {
+      const headers = new Headers(init?.headers);
+      if (headers.get('authorization') !== 'Bearer test-token') {
+        return new Response('missing test token', { status: 401 });
+      }
+      if (url === `${apiRoot}/check-runs/${intentCheckRunId}`) return jsonResponse(checkRun);
+      if (url === `${apiRoot}/releases/tags/${finalVerification.tag}`) {
+        return jsonResponse(release);
+      }
+      if (url === `${apiRoot}/releases/assets/${finalVerificationAssetId}`) {
+        if (headers.get('accept') !== 'application/octet-stream') {
+          return new Response('wrong media type', { status: 406 });
+        }
+        return new Response(finalAssetBytes, { status: 200 });
+      }
+      const tagPrefix = `${apiRoot}/git/ref/tags/`;
+      if (url.startsWith(tagPrefix)) {
+        const tag = decodeURIComponent(url.slice(tagPrefix.length));
+        const ref = refs[tag];
+        return ref === undefined ? new Response('missing ref', { status: 404 }) : jsonResponse(ref);
+      }
+    }
+    if (url === 'https://registry.npmjs.org/scriptspect/0.1.0') {
+      return jsonResponse(npmMetadata);
+    }
+    return new Response(`unexpected request: ${url}`, { status: 404 });
+  };
+}
+
+describe('remote README release evidence', () => {
+  it('accepts only a terminal receipt whose exact GitHub and npm evidence is still public', async () => {
+    const local = writeLocalEvidence();
+
+    await expect(
+      verifyReadmeReleaseEvidence({
+        ...local,
+        githubToken: 'test-token',
+        fetchImpl: remoteFetch(),
+      }),
+    ).resolves.toEqual({
+      releaseState: 'published',
+      remoteVerification: 'verified',
+      repository: receipt.repository,
+      packageName: 'scriptspect',
+      version: '0.1.0',
+      tag: 'v0.1.0',
+      commit: sourceCommit,
+      releaseId: 123456,
+      intentCheckRunId,
+      publishRunId,
+      finalVerificationAssetId,
+      finalVerificationDigest,
+    });
+  });
+
+  it('rejects a published status bound to another source commit before making requests', async () => {
+    const local = writeLocalEvidence({ sourceCommit: '0'.repeat(40) });
+    const remote = remoteFetch();
+    let requestCount = 0;
+    const fetchImpl: typeof fetch = (input, init) => {
+      requestCount += 1;
+      return remote(input, init);
+    };
+
+    await expect(
+      verifyReadmeReleaseEvidence({
+        ...local,
+        githubToken: 'test-token',
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/sourceCommit/i);
+    expect(requestCount).toBe(0);
+  });
+
+  it('validates pre-release status locally without a token or any network request', async () => {
+    const repositoryRoot = mkdtempSync(join(tmpdir(), 'scriptspect-readme-pre-release-'));
+    temporaryRoots.push(repositoryRoot);
+    const statusPath = join(repositoryRoot, 'docs', 'readme-status.json');
+    mkdirSync(join(repositoryRoot, 'docs'), { recursive: true });
+    writeFileSync(
+      statusPath,
+      `${JSON.stringify(
+        {
+          schemaVersion: 1,
+          releaseState: 'pre-release',
+          packageName: 'scriptspect',
+          packageVersion: '0.0.0',
+          sourceCommit,
+          nodeMajor: 22,
+          repository: receipt.repository,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    let requestCount = 0;
+    const fetchImpl: typeof fetch = async () => {
+      requestCount += 1;
+      return new Response('network must not be used', { status: 500 });
+    };
+
+    await expect(
+      verifyReadmeReleaseEvidence({ repositoryRoot, statusPath, fetchImpl }),
+    ).resolves.toEqual({
+      releaseState: 'pre-release',
+      remoteVerification: 'not-required',
+      repository: receipt.repository,
+      packageName: 'scriptspect',
+      packageVersion: '0.0.0',
+      sourceCommit,
+    });
+    expect(requestCount).toBe(0);
+  });
+
+  it('requires a token for published evidence before making a GitHub request', async () => {
+    const local = writeLocalEvidence();
+    const remote = remoteFetch();
+    let requestCount = 0;
+    const fetchImpl: typeof fetch = (input, init) => {
+      requestCount += 1;
+      return remote(input, init);
+    };
+
+    await expect(
+      verifyReadmeReleaseEvidence({
+        ...local,
+        githubToken: '',
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/GITHUB_TOKEN/u);
+    expect(requestCount).toBe(0);
+  });
+
+  it('rejects a receipt path that resolves outside docs/validation/releases without networking', async () => {
+    const local = writeLocalEvidence({
+      releaseEvidence: {
+        receiptPath: 'readme-release-receipt.json',
+        digest: canonicalJsonDigest(receipt),
+      },
+    });
+    writeFileSync(
+      join(local.repositoryRoot, 'docs', 'readme-release-receipt.json'),
+      `${JSON.stringify(receipt)}\n`,
+    );
+    let requestCount = 0;
+    const fetchImpl: typeof fetch = async () => {
+      requestCount += 1;
+      return new Response('network must not be used', { status: 500 });
+    };
+
+    await expect(
+      verifyReadmeReleaseEvidence({ ...local, githubToken: 'test-token', fetchImpl }),
+    ).rejects.toThrow(/docs\/validation\/releases/u);
+    expect(requestCount).toBe(0);
+  });
+
+  it('rejects an otherwise valid intent check that is not owned by github-actions', async () => {
+    const local = writeLocalEvidence();
+    const checkRun = checkRunFor() as Record<string, unknown>;
+
+    await expect(
+      verifyReadmeReleaseEvidence({
+        ...local,
+        githubToken: 'test-token',
+        fetchImpl: remoteFetch({ checkRun: { ...checkRun, app: { slug: 'other-app' } } }),
+      }),
+    ).rejects.toThrow(/app slug/u);
+  });
+
+  it.each([
+    ['status', 'in_progress'],
+    ['conclusion', 'failure'],
+  ])('rejects an intent check with non-terminal %s=%s', async (field, value) => {
+    const local = writeLocalEvidence();
+    const checkRun = checkRunFor() as Record<string, unknown>;
+
+    await expect(
+      verifyReadmeReleaseEvidence({
+        ...local,
+        githubToken: 'test-token',
+        fetchImpl: remoteFetch({ checkRun: { ...checkRun, [field]: value } }),
+      }),
+    ).rejects.toThrow(new RegExp(`intent check run ${field}`, 'u'));
+  });
+
+  it('rejects a successful intent check whose state has not reached consumed', async () => {
+    const local = writeLocalEvidence();
+    const { consumed: _consumed, ...finalPlanned } = consumedState;
+
+    await expect(
+      verifyReadmeReleaseEvidence({
+        ...local,
+        githubToken: 'test-token',
+        fetchImpl: remoteFetch({
+          checkRun: checkRunFor({ ...finalPlanned, state: 'final-planned' }),
+        }),
+      }),
+    ).rejects.toThrow(/must be consumed/u);
+  });
+
+  it('rejects a receipt publish run that is not the one persisted in terminal state', async () => {
+    const local = writeLocalEvidence();
+    const state = {
+      ...consumedState,
+      npmPublished: { ...consumedState.npmPublished, publishRunId: publishRunId + 1 },
+    };
+
+    await expect(
+      verifyReadmeReleaseEvidence({
+        ...local,
+        githubToken: 'test-token',
+        fetchImpl: remoteFetch({ checkRun: checkRunFor(state) }),
+      }),
+    ).rejects.toThrow(/publishRunId/u);
+  });
+
+  it('rejects a GitHub Release whose final asset digest differs from consumed state', async () => {
+    const local = writeLocalEvidence();
+    const release = releaseFixture() as {
+      assets: Array<{ id: number; name: string; digest: string }>;
+    };
+    const assets = release.assets.map((asset) =>
+      asset.id === finalVerificationAssetId
+        ? { ...asset, digest: `sha256:${'9'.repeat(64)}` }
+        : asset,
+    );
+
+    await expect(
+      verifyReadmeReleaseEvidence({
+        ...local,
+        githubToken: 'test-token',
+        fetchImpl: remoteFetch({ release: { ...release, assets } }),
+      }),
+    ).rejects.toThrow(/final verification digest/u);
+  });
+
+  it('rejects a GitHub Release that is still marked as a prerelease', async () => {
+    const local = writeLocalEvidence();
+    const release = releaseFixture() as Record<string, unknown>;
+
+    await expect(
+      verifyReadmeReleaseEvidence({
+        ...local,
+        githubToken: 'test-token',
+        fetchImpl: remoteFetch({ release: { ...release, prerelease: true } }),
+      }),
+    ).rejects.toThrow(/prerelease must be false/u);
+  });
+
+  it('rejects an immutable version tag that no longer targets the release commit', async () => {
+    const local = writeLocalEvidence();
+    const refs = refFixtures();
+    refs[finalVerification.tag] = {
+      ref: `refs/tags/${finalVerification.tag}`,
+      object: { type: 'commit', sha: '0'.repeat(40) },
+    };
+
+    await expect(
+      verifyReadmeReleaseEvidence({
+        ...local,
+        githubToken: 'test-token',
+        fetchImpl: remoteFetch({ refs }),
+      }),
+    ).rejects.toThrow(/v0\.1\.0 tag ref target/u);
+  });
+
+  it('rejects downloaded final-verification bytes with the wrong raw SHA-256', async () => {
+    const local = writeLocalEvidence();
+
+    await expect(
+      verifyReadmeReleaseEvidence({
+        ...local,
+        githubToken: 'test-token',
+        fetchImpl: remoteFetch({ finalAssetBytes: `${JSON.stringify(finalVerification)}\n` }),
+      }),
+    ).rejects.toThrow(/downloaded final verification SHA-256/u);
+  });
+
+  it('rejects npm exact-version metadata with a different dist.integrity', async () => {
+    const local = writeLocalEvidence();
+    const otherSRI = `sha512-${Buffer.alloc(64, 2).toString('base64')}`;
+
+    await expect(
+      verifyReadmeReleaseEvidence({
+        ...local,
+        githubToken: 'test-token',
+        fetchImpl: remoteFetch({
+          npmMetadata: {
+            name: 'scriptspect',
+            version: finalVerification.version,
+            dist: {
+              integrity: otherSRI,
+              tarball: 'https://registry.npmjs.org/scriptspect/-/scriptspect-0.1.0.tgz',
+            },
+          },
+        }),
+      }),
+    ).rejects.toThrow(/dist\.integrity/u);
+  });
+
+  it.each(['v0.1', 'v0'])(
+    'rejects floating alias %s when it no longer targets the release commit',
+    async (alias) => {
+      const local = writeLocalEvidence();
+      const refs = refFixtures();
+      refs[alias] = {
+        ref: `refs/tags/${alias}`,
+        object: { type: 'commit', sha: '0'.repeat(40) },
+      };
+
+      await expect(
+        verifyReadmeReleaseEvidence({
+          ...local,
+          githubToken: 'test-token',
+          fetchImpl: remoteFetch({ refs }),
+        }),
+      ).rejects.toThrow(new RegExp(`${alias.replaceAll('.', '\\.')} tag ref target`, 'u'));
+    },
+  );
+});

--- a/tests/docs/readme-release-receipt.test.ts
+++ b/tests/docs/readme-release-receipt.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import {
+  validateReadmeReleaseReceipt,
+  validateReceiptAgainstStatus,
+} from '../../tools/readme-release-receipt.js';
+
+const sourceCommit = 'bf37b4132508c685a91cc16a9c0a3058c252502e';
+const npmSRI =
+  'sha512-AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ==';
+
+const finalVerification = {
+  schemaVersion: 'scriptspect-final-verification/v1',
+  intentId: `scriptspect-release-intent:66:${sourceCommit}`,
+  version: '0.1.0',
+  tag: 'v0.1.0',
+  commit: sourceCommit,
+  releaseId: 123456,
+  candidateManifestDigest: 'a'.repeat(64),
+  releaseManifestDigest: 'b'.repeat(64),
+  candidateNpmSRI: npmSRI,
+  registryNpmSRI: npmSRI,
+  provenanceDigest: 'c'.repeat(64),
+  aliases: [
+    { name: 'v0.1', target: sourceCommit },
+    { name: 'v0', target: sourceCommit },
+  ],
+} as const;
+
+const validReceipt = {
+  schemaVersion: 'scriptspect-readme-release-receipt/v1',
+  repository: 'https://github.com/Tom409114/scriptspect',
+  intentCheckRunId: 123456789,
+  finalVerificationAssetId: 234567890,
+  finalVerificationDigest: 'ad725d63c2f5b3b5776f91b3c15695417d1d35d78ccaaecc534e266354cf5fe6',
+  publishRunId: 345678901,
+  finalVerification,
+} as const;
+
+const normalizedReceipt = {
+  schemaVersion: 'scriptspect-readme-release-receipt/v1',
+  repository: 'https://github.com/Tom409114/scriptspect',
+  intentCheckRunId: 123456789,
+  finalVerificationAssetId: 234567890,
+  finalVerificationDigest: 'ad725d63c2f5b3b5776f91b3c15695417d1d35d78ccaaecc534e266354cf5fe6',
+  publishRunId: 345678901,
+  finalVerification: {
+    schemaVersion: 'scriptspect-final-verification/v1',
+    intentId: `scriptspect-release-intent:66:${sourceCommit}`,
+    version: '0.1.0',
+    tag: 'v0.1.0',
+    commit: sourceCommit,
+    releaseId: 123456,
+    candidateManifestDigest: 'a'.repeat(64),
+    releaseManifestDigest: 'b'.repeat(64),
+    candidateNpmSRI: npmSRI,
+    registryNpmSRI: npmSRI,
+    provenanceDigest: 'c'.repeat(64),
+    aliases: [
+      { name: 'v0.1', target: sourceCommit },
+      { name: 'v0', target: sourceCommit },
+    ],
+  },
+} as const;
+
+const publishedStatus = {
+  schemaVersion: 1,
+  releaseState: 'published',
+  packageName: 'scriptspect',
+  packageVersion: '0.1.0',
+  sourceCommit,
+  nodeMajor: 22,
+  repository: 'https://github.com/Tom409114/scriptspect',
+  releaseEvidence: {
+    receiptPath: 'validation/releases/v0.1.0/readme-release-receipt.json',
+    digest: '2a2a6a43426e639aa6ce022b6662db48e61f072481f3209feb04dc44db3a910f',
+  },
+} as const;
+
+describe('README release receipt', () => {
+  it('validates and normalizes an exact receipt', () => {
+    expect(validateReadmeReleaseReceipt(validReceipt)).toEqual(normalizedReceipt);
+  });
+
+  it('rejects missing and unexpected receipt keys', () => {
+    expect(() => validateReadmeReleaseReceipt({ ...validReceipt, unexpected: true })).toThrow(
+      /exact keys/u,
+    );
+
+    const { publishRunId: _publishRunId, ...missingPublishRun } = validReceipt;
+    expect(() => validateReadmeReleaseReceipt(missingPublishRun)).toThrow(/exact keys/u);
+  });
+
+  it('rejects the wrong schema, repository, or non-positive identifiers', () => {
+    const cases: Array<[unknown, RegExp]> = [
+      [
+        { ...validReceipt, schemaVersion: 'scriptspect-readme-release-receipt/v2' },
+        /schemaVersion/u,
+      ],
+      [{ ...validReceipt, repository: 'https://github.com/someone/else' }, /repository/u],
+      [{ ...validReceipt, intentCheckRunId: 0 }, /intentCheckRunId/u],
+      [{ ...validReceipt, intentCheckRunId: Number.MAX_SAFE_INTEGER + 1 }, /intentCheckRunId/u],
+      [{ ...validReceipt, finalVerificationAssetId: -1 }, /finalVerificationAssetId/u],
+      [{ ...validReceipt, publishRunId: 1.5 }, /publishRunId/u],
+      [{ ...validReceipt, publishRunId: Number.MAX_SAFE_INTEGER + 1 }, /publishRunId/u],
+    ];
+
+    for (const [receipt, message] of cases) {
+      expect(() => validateReadmeReleaseReceipt(receipt)).toThrow(message);
+    }
+  });
+
+  it('requires the recorded SHA-256 to match the normalized final verification', () => {
+    expect(() =>
+      validateReadmeReleaseReceipt({ ...validReceipt, finalVerificationDigest: 'not-a-sha256' }),
+    ).toThrow(/finalVerificationDigest/u);
+    expect(() =>
+      validateReadmeReleaseReceipt({ ...validReceipt, finalVerificationDigest: 'd'.repeat(64) }),
+    ).toThrow(/does not match/u);
+  });
+
+  it('cross-checks a published status and returns the normalized receipt', () => {
+    expect(validateReceiptAgainstStatus(validReceipt, publishedStatus)).toEqual(normalizedReceipt);
+  });
+
+  it('rejects a receipt while the homepage remains pre-release', () => {
+    expect(() =>
+      validateReceiptAgainstStatus(validReceipt, {
+        ...publishedStatus,
+        releaseState: 'pre-release',
+      }),
+    ).toThrow(/pre-release/u);
+  });
+
+  it('rejects published status fields that disagree with the receipt', () => {
+    const cases: Array<[unknown, RegExp]> = [
+      [{ ...publishedStatus, packageName: 'someone-else' }, /packageName/u],
+      [{ ...publishedStatus, packageVersion: '0.2.0' }, /packageVersion/u],
+      [{ ...publishedStatus, sourceCommit: 'd'.repeat(40) }, /sourceCommit/u],
+      [{ ...publishedStatus, repository: 'https://github.com/someone/else' }, /repository/u],
+      [{ ...publishedStatus, releaseEvidence: undefined }, /releaseEvidence/u],
+      [
+        {
+          ...publishedStatus,
+          releaseEvidence: { ...publishedStatus.releaseEvidence, unexpected: true },
+        },
+        /releaseEvidence/u,
+      ],
+      [
+        {
+          ...publishedStatus,
+          releaseEvidence: { ...publishedStatus.releaseEvidence, receiptPath: '' },
+        },
+        /receiptPath/u,
+      ],
+      [
+        {
+          ...publishedStatus,
+          releaseEvidence: {
+            ...publishedStatus.releaseEvidence,
+            receiptPath: '../outside.json',
+          },
+        },
+        /receiptPath/u,
+      ],
+      [
+        {
+          ...publishedStatus,
+          releaseEvidence: { ...publishedStatus.releaseEvidence, digest: 'e'.repeat(64) },
+        },
+        /digest/u,
+      ],
+    ];
+
+    for (const [status, message] of cases) {
+      expect(() => validateReceiptAgainstStatus(validReceipt, status)).toThrow(message);
+    }
+  });
+});

--- a/tests/release/npm-bootstrap-state.test.ts
+++ b/tests/release/npm-bootstrap-state.test.ts
@@ -1,0 +1,345 @@
+import { type SpawnSyncReturns, spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = resolve(import.meta.dirname, '../..');
+const tool = resolve(root, 'tools/release/verify-npm-bootstrap-state.mjs');
+const anchorTool = resolve(root, 'tools/release/verify-npm-bootstrap-anchor.mjs');
+const sourceSha = 'a'.repeat(40);
+const bootstrapVersion = '0.0.0-bootstrap.0';
+const bootstrapTarball = `scriptspect-${bootstrapVersion}.tgz`;
+const bootstrapTarballSha = 'efd8427d802796f53752d589719c967b0eb1a64227449f41ed5e438b46974c09';
+const emptyDistTagsSha = 'ca3d163bab055381827226140568f3bef7eaac187cebd76878e0b63e9e442356';
+
+function verifyArtifactProvenance(
+  overrides: {
+    artifactHeadRepositoryId?: number;
+    artifactHeadSha?: string;
+    runBranch?: string;
+    runEvent?: string;
+    runPath?: string;
+    runWorkflowId?: number;
+  } = {},
+): SpawnSyncReturns<string> {
+  const directory = mkdtempSync(join(tmpdir(), 'scriptspect-npm-anchor-provenance-'));
+  const artifactName = `npm-bootstrap-anchor-0.0.0-bootstrap.0-${sourceSha}`;
+  const fixtures = {
+    artifacts: {
+      total_count: 1,
+      artifacts: [
+        {
+          id: 101,
+          name: artifactName,
+          expired: false,
+          digest: `sha256:${'b'.repeat(64)}`,
+          workflow_run: {
+            id: 202,
+            repository_id: 303,
+            head_repository_id: overrides.artifactHeadRepositoryId ?? 303,
+            head_branch: 'main',
+            head_sha: overrides.artifactHeadSha ?? sourceSha,
+          },
+        },
+      ],
+    },
+    run: {
+      id: 202,
+      event: overrides.runEvent ?? 'workflow_dispatch',
+      head_branch: overrides.runBranch ?? 'main',
+      head_sha: sourceSha,
+      path: overrides.runPath ?? '.github/workflows/npm-bootstrap.yml',
+      workflow_id: overrides.runWorkflowId ?? 404,
+      repository: { id: 303, full_name: 'Tom409114/scriptspect' },
+      head_repository: { id: 303, full_name: 'Tom409114/scriptspect' },
+    },
+    workflow: {
+      id: 404,
+      path: '.github/workflows/npm-bootstrap.yml',
+      state: 'active',
+    },
+    repository: { id: 303, full_name: 'Tom409114/scriptspect' },
+  };
+  const paths: Record<string, string> = {};
+  for (const [name, value] of Object.entries(fixtures)) {
+    paths[name] = join(directory, `${name}.json`);
+    writeFileSync(paths[name], JSON.stringify(value));
+  }
+  try {
+    return spawnSync(
+      process.execPath,
+      [
+        anchorTool,
+        'provenance',
+        '--artifacts',
+        paths.artifacts ?? '',
+        '--run',
+        paths.run ?? '',
+        '--workflow',
+        paths.workflow ?? '',
+        '--repository',
+        paths.repository ?? '',
+        '--artifact-name',
+        artifactName,
+        '--repository-name',
+        'Tom409114/scriptspect',
+        '--source-sha',
+        sourceSha,
+      ],
+      { cwd: root, encoding: 'utf8' },
+    );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function verifyAnchorFiles(
+  overrides: {
+    anchorBasename?: string;
+    anchorSha?: string;
+    checksumBasename?: string;
+    checksumSha?: string;
+    distTagsBeforeDigest?: string;
+    extraTarball?: boolean;
+  } = {},
+): SpawnSyncReturns<string> {
+  const directory = mkdtempSync(join(tmpdir(), 'scriptspect-npm-anchor-files-'));
+  writeFileSync(join(directory, bootstrapTarball), 'trusted bootstrap tarball\n');
+  writeFileSync(
+    join(directory, 'SHA256SUMS'),
+    `${overrides.checksumSha ?? bootstrapTarballSha}  ${
+      overrides.checksumBasename ?? bootstrapTarball
+    }\n`,
+  );
+  if (overrides.extraTarball === true) {
+    writeFileSync(join(directory, 'scriptspect-0.0.0-bootstrap.1.tgz'), 'other tarball\n');
+  }
+  writeFileSync(join(directory, 'dist-tags-before.json'), '{}\n');
+  writeFileSync(
+    join(directory, 'bootstrap-anchor.json'),
+    `${JSON.stringify({
+      schemaVersion: 'scriptspect-bootstrap-anchor/v1',
+      sourceCommit: sourceSha,
+      version: bootstrapVersion,
+      tarball: {
+        basename: overrides.anchorBasename ?? bootstrapTarball,
+        sha256: overrides.anchorSha ?? bootstrapTarballSha,
+      },
+      distTagsBeforeDigest: overrides.distTagsBeforeDigest ?? emptyDistTagsSha,
+    })}\n`,
+  );
+  try {
+    return spawnSync(
+      process.execPath,
+      [
+        anchorTool,
+        'files',
+        '--directory',
+        directory,
+        '--source-sha',
+        sourceSha,
+        '--version',
+        bootstrapVersion,
+      ],
+      { cwd: root, encoding: 'utf8' },
+    );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function verify(input: {
+  owners: unknown;
+  before: unknown;
+  after: unknown;
+  owner?: string;
+  version?: string;
+}) {
+  const directory = mkdtempSync(join(tmpdir(), 'scriptspect-npm-bootstrap-'));
+  const owners = join(directory, 'owners.json');
+  const before = join(directory, 'before.json');
+  const after = join(directory, 'after.json');
+  writeFileSync(owners, JSON.stringify(input.owners));
+  writeFileSync(before, JSON.stringify(input.before));
+  writeFileSync(after, JSON.stringify(input.after));
+  try {
+    return spawnSync(
+      process.execPath,
+      [
+        tool,
+        '--owners',
+        owners,
+        '--owner',
+        input.owner ?? 'Tom409114',
+        '--before',
+        before,
+        '--after',
+        after,
+        '--version',
+        input.version ?? '0.0.0-bootstrap.0',
+      ],
+      { cwd: root, encoding: 'utf8' },
+    );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function normalize(input: unknown, type: 'object' | 'string'): SpawnSyncReturns<string> {
+  const directory = mkdtempSync(join(tmpdir(), 'scriptspect-npm-view-'));
+  const inputPath = join(directory, 'input.json');
+  writeFileSync(inputPath, JSON.stringify(input));
+  try {
+    return spawnSync(process.execPath, [tool, 'normalize', '--input', inputPath, '--type', type], {
+      cwd: root,
+      encoding: 'utf8',
+    });
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+describe('npm bootstrap registry state verifier', () => {
+  it('normalizes npm 11 values and npm 12 singleton result arrays', () => {
+    for (const input of ['0.0.0-bootstrap.0', ['0.0.0-bootstrap.0']]) {
+      const result = normalize(input, 'string');
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toBe('0.0.0-bootstrap.0\n');
+    }
+
+    for (const input of [{ latest: '1.2.3' }, [{ latest: '1.2.3' }]]) {
+      const result = normalize(input, 'object');
+      expect(result.status, result.stderr).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual({ latest: '1.2.3' });
+    }
+  });
+
+  it('can verify existing package ownership before any publication attempt', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'scriptspect-npm-owner-'));
+    const owners = join(directory, 'owners.json');
+    writeFileSync(owners, JSON.stringify(['Tom409114 <tom@example.test>']));
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [tool, '--owners', owners, '--owner', 'Tom409114'],
+        { cwd: root, encoding: 'utf8' },
+      );
+      expect(result.status, result.stderr).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual({ owner: 'Tom409114' });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('normalizes npm maintainer JSON and accepts an idempotent post-publish retry', () => {
+    for (const owners of [
+      ['Tom409114 <tom@example.test>'],
+      [['Tom409114 <tom@example.test>']],
+      [{ name: 'Tom409114', email: 'tom@example.test' }],
+      ['Tom409114 <tom@example.test>', { name: 'tom409114', email: 'same@example.test' }],
+    ]) {
+      const result = verify({
+        owners,
+        before: [{}],
+        after: [{ bootstrap: '0.0.0-bootstrap.0' }],
+      });
+      expect(result.status, result.stderr).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual({
+        owner: 'Tom409114',
+        version: '0.0.0-bootstrap.0',
+        latestBefore: null,
+        latestAfter: null,
+        bootstrap: '0.0.0-bootstrap.0',
+      });
+    }
+  });
+
+  it('rejects any additional maintainer after case-insensitive deduplication', () => {
+    const result = verify({
+      owners: [
+        'Tom409114 <tom@example.test>',
+        { name: 'attacker', email: 'attacker@example.test' },
+      ],
+      before: {},
+      after: { bootstrap: '0.0.0-bootstrap.0' },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('only the expected npm owner');
+  });
+
+  it('rejects a missing owner, a moved latest tag, or the wrong bootstrap tag', () => {
+    const cases = [
+      verify({
+        owners: ['someone-else <else@example.test>'],
+        before: {},
+        after: { bootstrap: '0.0.0-bootstrap.0' },
+      }),
+      verify({
+        owners: ['Tom409114 <tom@example.test>'],
+        before: { latest: '1.2.3' },
+        after: { latest: '1.2.4', bootstrap: '0.0.0-bootstrap.0' },
+      }),
+      verify({
+        owners: ['Tom409114 <tom@example.test>'],
+        before: {},
+        after: { bootstrap: '0.0.0-bootstrap.1' },
+      }),
+    ];
+
+    for (const result of cases) expect(result.status).not.toBe(0);
+    expect(cases[0]?.stderr).toContain('authenticated npm owner is not a package maintainer');
+    expect(cases[1]?.stderr).toContain('latest dist-tag changed during bootstrap');
+    expect(cases[2]?.stderr).toContain('bootstrap dist-tag does not match the requested version');
+  });
+});
+
+describe('npm bootstrap recovery anchor verifier', () => {
+  it('accepts an anchor only from the exact trusted bootstrap workflow run', () => {
+    const result = verifyArtifactProvenance();
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      artifactId: 101,
+      artifactDigest: `sha256:${'b'.repeat(64)}`,
+      runId: 202,
+      sourceCommit: sourceSha,
+      workflowId: 404,
+    });
+  });
+
+  it('rejects an artifact that is not bound to the exact trusted run identity', () => {
+    const cases = [
+      verifyArtifactProvenance({ artifactHeadRepositoryId: 999 }),
+      verifyArtifactProvenance({ artifactHeadSha: 'c'.repeat(40) }),
+      verifyArtifactProvenance({ runBranch: 'feature/untrusted' }),
+      verifyArtifactProvenance({ runEvent: 'pull_request' }),
+      verifyArtifactProvenance({ runPath: '.github/workflows/ci.yml' }),
+      verifyArtifactProvenance({ runWorkflowId: 999 }),
+    ];
+    for (const result of cases) expect(result.status).not.toBe(0);
+  });
+
+  it('accepts one anchor whose manifest and checksum bind the exact tarball', () => {
+    const result = verifyAnchorFiles();
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      sourceCommit: sourceSha,
+      version: bootstrapVersion,
+      tarball: { basename: bootstrapTarball, sha256: bootstrapTarballSha },
+      distTagsBeforeDigest: emptyDistTagsSha,
+    });
+  });
+
+  it('rejects ambiguous or self-inconsistent recovered anchor files', () => {
+    const cases = [
+      verifyAnchorFiles({ extraTarball: true }),
+      verifyAnchorFiles({ anchorSha: 'c'.repeat(64) }),
+      verifyAnchorFiles({ checksumSha: 'd'.repeat(64) }),
+      verifyAnchorFiles({ checksumBasename: 'scriptspect-0.0.0-bootstrap.1.tgz' }),
+      verifyAnchorFiles({ anchorBasename: 'scriptspect-0.0.0-bootstrap.1.tgz' }),
+      verifyAnchorFiles({ distTagsBeforeDigest: 'e'.repeat(64) }),
+    ];
+    for (const result of cases) expect(result.status).not.toBe(0);
+  });
+});

--- a/tests/release/readme-release-handoff.test.ts
+++ b/tests/release/readme-release-handoff.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+const root = resolve(import.meta.dirname, '../..');
+const read = (path: string): string => readFileSync(resolve(root, path), 'utf8');
+
+type Step = {
+  name?: string;
+  uses?: string;
+  run?: string;
+  with?: Record<string, unknown>;
+};
+
+describe('published homepage handoff', () => {
+  it('creates the receipt only after the consumed release state is durable', () => {
+    const workflow = parse(read('.github/workflows/npm-publish.yml')) as {
+      jobs?: Record<string, { steps?: Step[] }>;
+    };
+    const steps = workflow.jobs?.['record-verification']?.steps ?? [];
+    const recorder = steps.find((step) => step.name?.includes('idempotent final evidence'));
+    const upload = steps.find((step) => step.name === 'Upload the terminal README handoff receipt');
+    const run = recorder?.run ?? '';
+
+    const consumedState = run.indexOf('approved-consumed-state.json');
+    const consumedPatch = run.indexOf('summary:"Final verification is exact and idempotent"');
+    const receipt = run.indexOf('scriptspect-readme-release-receipt/v1');
+    expect(consumedState).toBeGreaterThanOrEqual(0);
+    expect(consumedPatch).toBeGreaterThan(consumedState);
+    expect(receipt).toBeGreaterThan(consumedPatch);
+    expect(run).toContain('--argjson intentCheckRunId "$INTENT_ID"');
+    expect(run).toContain('--argjson finalVerificationAssetId "$FINAL_ASSET_ID"');
+    expect(run).toContain("'.npmPublished.publishRunId'");
+    expect(run).toContain('--slurpfile finalVerification');
+
+    expect(steps.indexOf(upload as Step)).toBeGreaterThan(steps.indexOf(recorder as Step));
+    expect(upload?.uses).toBe('actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a');
+    expect(upload?.with).toMatchObject({
+      name: `readme-release-receipt-v\${{ needs.publish.outputs.version }}`,
+      path: `\${{ runner.temp }}/readme-release-receipt.json`,
+      'if-no-files-found': 'error',
+    });
+  });
+
+  it('documents and enforces the separate evidence-backed README PR', () => {
+    const generator = read('tools/generate-readme-status.ts');
+    const runbook = read('docs/release-readme.md');
+    const ci = read('.github/workflows/ci.yml');
+
+    expect(generator).toContain('published README state requires --receipt terminal evidence');
+    expect(generator).toContain('validateReceiptAgainstStatus');
+    expect(runbook).toContain('The transition is deliberately a second pull request');
+    expect(runbook).toContain('--published');
+    expect(runbook).toContain('--receipt');
+    expect(runbook).toContain('Update `SECURITY.md`');
+    expect(runbook).toContain('Keep the post-release artifact policy in');
+    expect(runbook).toContain('VERSION=0.1.0');
+    expect(runbook).toContain('RELEASE_COMMIT="$(git rev-parse');
+    expect(runbook).toContain('export GITHUB_TOKEN="$(gh auth token)"');
+    expect(runbook).not.toMatch(/<(?:RELEASE_COMMIT|VERSION|read-only-token)>/u);
+    expect(runbook).toContain('verify-readme-release-evidence.ts');
+    expect(ci).toContain('pnpm exec tsx tools/verify-readme-release-evidence.ts');
+  });
+});

--- a/tests/release/release-contract.test.ts
+++ b/tests/release/release-contract.test.ts
@@ -24,6 +24,7 @@ const canonicalTreeAlgorithmDigest = (
 type Step = {
   name?: string;
   id?: string;
+  if?: string;
   uses?: string;
   run?: string;
   env?: Record<string, string>;
@@ -763,6 +764,33 @@ describe('release coordinator trust and recovery', () => {
     expect(test).toBeGreaterThan(build);
   });
 
+  it('packs exact-version bilingual npm READMEs without changing the repository homepages', () => {
+    const releaseCandidate = jobSource('release.yml', 'build-candidate');
+    const bootstrapCandidate = jobSource('npm-bootstrap.yml', 'bootstrap');
+    const publisher = jobSource('npm-publish.yml', 'publish');
+
+    for (const candidate of [releaseCandidate, bootstrapCandidate]) {
+      expect(candidate).toContain('tools/release/generate-package-readmes.mjs');
+      expect(candidate).toContain('package-stage');
+      expect(candidate).toContain('git archive');
+      expect(candidate).toContain('cp -R dist schema "$PACKAGE_STAGE/"');
+      expect(candidate).toContain('git diff --exit-code -- README.md README.zh-CN.md');
+      expect(candidate.indexOf('tools/release/generate-package-readmes.mjs')).toBeLessThan(
+        candidate.indexOf('pnpm pack'),
+      );
+      expect(candidate).toContain('tar -xOf');
+      expect(candidate).toContain('README.zh-CN.md');
+    }
+    expect(releaseCandidate).toContain('npx --yes scriptspect@$VERSION .');
+    expect(bootstrapCandidate).toContain('--channel bootstrap');
+    expect(publisher).toContain('tools/release/generate-package-readmes.mjs');
+    expect(publisher).toContain('--channel stable');
+    expect(publisher).toContain('cmp "$EXPECTED_READMES/$README"');
+    expect(publisher.indexOf('tools/release/generate-package-readmes.mjs')).toBeLessThan(
+      publisher.indexOf('npm publish'),
+    );
+  });
+
   it('serializes every state mutation under one per-SHA mutex and every publisher under one alias mutex', () => {
     expect(workflow('release-intent.yml').jobs?.['record-intent']?.concurrency).toEqual({
       group: `release-state-\${{ github.repository }}-\${{ github.sha }}`,
@@ -1032,46 +1060,186 @@ describe('release coordinator trust and recovery', () => {
 });
 
 describe('one-time npm bootstrap', () => {
-  it('is manual, separately approved, prerelease-only, and never moves latest', () => {
+  it('isolates candidate preparation, one-time credentials, and public verification', () => {
     const bootstrap = workflow('npm-bootstrap.yml');
     expect(bootstrap.on).toHaveProperty('workflow_dispatch');
-    expect(bootstrap.jobs?.bootstrap?.environment).toBe('npm-bootstrap');
-
-    const run = jobSource('npm-bootstrap.yml', 'bootstrap');
-    expect(source('npm-bootstrap.yml')).toContain('default: 0.0.0-bootstrap.0');
-    expect(run).toContain('--tag bootstrap');
-    expect(run).toContain('npm dist-tag ls');
-    expect(run).toContain('NPM_BOOTSTRAP_TOKEN');
-    expect(source('npm-bootstrap.yml')).toContain('registry-url: https://registry.npmjs.org');
-    expect(run).toContain('npm version "$VERSION"');
-    expect(run).toContain('pnpm build');
-    expect(run).toContain('pnpm exec vitest run');
-    expect(run.indexOf('npm version "$VERSION"')).toBeLessThan(run.indexOf('pnpm build'));
-    expect(run.indexOf('pnpm build')).toBeLessThan(run.indexOf('pnpm exec vitest run'));
-    expect(run).toContain('already-published');
-    expect(run).toContain('node_modules/scriptspect/dist/cli.mjs');
-    expect(run).toContain('node_modules/scriptspect/schema/config.schema.json');
-    expect(run).toContain('node_modules/scriptspect/dist/action.mjs');
-    expect(run).toContain('canonical-tree');
-    expect(run).toContain('comparatorAlgorithmDigest');
-    expect(run).toContain('canonical-tree.mjs algorithm-digest');
-    expect(run).toContain('comparator-source-bundle.json');
-    expect(source('npm-bootstrap.yml')).toContain(
-      `\${{ runner.temp }}/bootstrap/comparator-source-bundle.json`,
-    );
-    expect(bootstrap.jobs?.bootstrap?.concurrency).toEqual({
+    expect(bootstrap.concurrency).toEqual({
       group: `npm-bootstrap-\${{ github.repository }}`,
       'cancel-in-progress': false,
     });
-    expect(run).toContain('bootstrap-anchor.json');
-    expect(run).toContain('dist-tags-before.json');
-    expect(run).toContain('actions/artifacts');
-    expect(run).toContain('sha256sum --check SHA256SUMS');
-    expect(run).toContain('canonical-tree.mjs digest --tarball');
-    expect(run.indexOf('bootstrap-anchor.json')).toBeLessThan(run.indexOf('npm publish'));
-    expect(run).toMatch(/sha256sum "\$TARBALL_BASENAME" > SHA256SUMS/);
-    expect(run).not.toMatch(/sha256sum "\$TARBALL" > .*SHA256SUMS/);
-    expect(run).not.toMatch(/npm publish[^\n]*0\.1\.0/);
+
+    const prepareJob = bootstrap.jobs?.bootstrap;
+    const publishJob = bootstrap.jobs?.publish_bootstrap;
+    const verifyJob = bootstrap.jobs?.verify_bootstrap;
+    expect(prepareJob?.environment).toBeUndefined();
+    expect(publishJob?.environment).toBe('npm-bootstrap');
+    expect(verifyJob?.environment).toBeUndefined();
+    expect(publishJob?.needs).toEqual(['bootstrap']);
+    expect(verifyJob?.needs).toEqual(['bootstrap', 'publish_bootstrap']);
+    expect(verifyJob?.if).toContain("needs.bootstrap.outputs.needs-publish != 'true'");
+    expect(verifyJob?.if).toContain("needs.publish_bootstrap.result == 'success'");
+
+    const prepare = jobSource('npm-bootstrap.yml', 'bootstrap');
+    const publish = jobSource('npm-bootstrap.yml', 'publish_bootstrap');
+    const verify = jobSource('npm-bootstrap.yml', 'verify_bootstrap');
+    const allRun = [prepare, publish, verify].join('\n');
+    const prepareSteps = prepareJob?.steps ?? [];
+    const publishSteps = publishJob?.steps ?? [];
+    const verifySteps = verifyJob?.steps ?? [];
+    const allSteps = [...prepareSteps, ...publishSteps, ...verifySteps];
+
+    const validation = prepareSteps.find(
+      (step) => step.name === 'Validate the approved request and exact successful CI run',
+    )?.run;
+    const recovery = prepareSteps.find(
+      (step) => step.name === 'Recover the single crash-stable pre-publish anchor',
+    )?.run;
+    const build = prepareSteps.find(
+      (step) => step.name === 'Version first, then build and pack the bootstrap prerelease once',
+    )?.run;
+    const candidateGateStep = prepareSteps.find(
+      (step) => step.name === 'Gate the exact candidate against the public registry',
+    );
+    const handoffStep = prepareSteps.find(
+      (step) => step.name === 'Hand the verified candidate to a fresh publisher runner',
+    );
+    const freshPreflightStep = publishSteps.find(
+      (step) =>
+        step.name === 'Revalidate current main, handoff bytes, package name, and public owner',
+    );
+    const credentialStep = publishSteps.find(
+      (step) => step.name === 'Publish the bootstrap candidate with the one-time credential',
+    );
+    const publicStateStep = verifySteps.find(
+      (step) => step.name === 'Verify exact public bootstrap registry state',
+    );
+    const registryVerification = verifySteps.find(
+      (step) => step.name === 'Verify registry bytes, canonical tree, CLI, schemas, and Action',
+    )?.run;
+    const candidateGate = candidateGateStep?.run;
+    const freshPreflight = freshPreflightStep?.run;
+    const credentialPublication = credentialStep?.run;
+    const publicState = publicStateStep?.run;
+
+    expect(validation).toBeDefined();
+    expect(recovery).toBeDefined();
+    expect(build).toBeDefined();
+    expect(candidateGate).toBeDefined();
+    expect(freshPreflight).toBeDefined();
+    expect(credentialPublication).toBeDefined();
+    expect(publicState).toBeDefined();
+    expect(registryVerification).toBeDefined();
+    expect(handoffStep?.uses).toBe(
+      'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a',
+    );
+    expect(handoffStep?.with?.name).toBe(`npm-bootstrap-handoff-\${{ github.run_id }}`);
+
+    expect(source('npm-bootstrap.yml')).toContain('default: 0.0.0-bootstrap.0');
+    expect(publish).toContain('--tag bootstrap');
+    expect(allRun).not.toContain('npm dist-tag ls');
+    expect(allRun).not.toContain('npm owner ls');
+    expect(verify).toContain('npm view scriptspect dist-tags --json');
+    expect(verify).toContain('npm view scriptspect maintainers --json');
+    expect(verify).toContain('verify-npm-bootstrap-state.mjs');
+    expect(source('npm-bootstrap.yml')).toContain('registry-url: https://registry.npmjs.org');
+    expect(prepare).toContain('npm version "$VERSION"');
+    expect(prepare).toContain('pnpm build');
+    expect(prepare).toContain('pnpm exec vitest run');
+    expect(prepare.indexOf('npm version "$VERSION"')).toBeLessThan(prepare.indexOf('pnpm build'));
+    expect(prepare.indexOf('pnpm build')).toBeLessThan(prepare.indexOf('pnpm exec vitest run'));
+    expect(build?.match(/pnpm build/gu)).toHaveLength(2);
+    expect(build).toContain('bootstrap-first-build');
+    expect(build).toContain('diff -qr "$RUNNER_TEMP/bootstrap-first-build/dist" dist');
+    expect(candidateGateStep?.id).toBe('registry');
+    expect(prepare).toContain('needs-publish');
+    expect(allRun).toContain('node_modules/scriptspect/dist/cli.mjs');
+    expect(allRun).toContain('node_modules/scriptspect/schema/config.schema.json');
+    expect(allRun).toContain('node_modules/scriptspect/dist/action.mjs');
+    expect(verify).toContain('canonical-tree');
+    expect(verify).toContain('comparatorAlgorithmDigest');
+    expect(verify).toContain('canonical-tree.mjs algorithm-digest');
+    expect(verify).toContain('comparator-source-bundle.json');
+    expect(source('npm-bootstrap.yml')).toContain(
+      `\${{ runner.temp }}/bootstrap/comparator-source-bundle.json`,
+    );
+    expect(prepare).toContain('bootstrap-anchor.json');
+    expect(prepare).toContain('dist-tags-before.json');
+    expect(prepare).toContain('actions/artifacts');
+    expect(prepare).toContain('published bootstrap version exists without the retained anchor');
+    expect(validation).toContain('git fetch --no-tags origin main');
+    expect(validation).toContain('git merge-base --is-ancestor "$SOURCE_SHA" origin/main');
+    expect(validation).toContain('.path == ".github/workflows/ci.yml"');
+    expect(validation).toContain('.head_repository.full_name == $repository');
+    expect(validation).toContain('.conclusion == "success"');
+    expect(validation?.indexOf('git merge-base --is-ancestor')).toBeLessThan(
+      validation?.indexOf('node tools/release/release-state.mjs') ?? -1,
+    );
+    expect(validation?.indexOf('.conclusion == "success"')).toBeLessThan(
+      validation?.indexOf('node tools/release/release-state.mjs') ?? -1,
+    );
+
+    const secretBearingSteps = allSteps.filter((step) =>
+      Object.values(step.env ?? {}).some((value) => value.includes('secrets.NPM_BOOTSTRAP_TOKEN')),
+    );
+    expect(secretBearingSteps).toHaveLength(1);
+    expect(prepareSteps.some((step) => step.uses?.startsWith('actions/checkout@'))).toBe(true);
+    expect(publishSteps.some((step) => step.uses?.startsWith('actions/checkout@'))).toBe(false);
+    expect(verifySteps.some((step) => step.uses?.startsWith('actions/checkout@'))).toBe(true);
+    expect(prepare).not.toContain('NPM_BOOTSTRAP_TOKEN');
+    expect(secretBearingSteps[0]).toBe(credentialStep);
+    expect(freshPreflightStep?.env?.EXPECTED_NPM_OWNER).toBe('Tom409114');
+    expect(credentialStep?.env?.EXPECTED_NPM_OWNER).toBe('Tom409114');
+    expect(credentialStep?.if).toContain("steps.fresh-registry.outputs.publish-now == 'true'");
+    expect(freshPreflight).not.toMatch(/\bnode\s+tools\//u);
+    expect(freshPreflight).not.toContain('pnpm ');
+    expect(credentialPublication).toContain(`[[ "\${OWNER,,}" == "\${EXPECTED_NPM_OWNER,,}" ]]`);
+    expect(credentialPublication?.indexOf(`[[ "\${OWNER,,}"`)).toBeLessThan(
+      credentialPublication?.indexOf('npm publish') ?? -1,
+    );
+    expect(credentialPublication).not.toMatch(/\bnode\s+tools\//u);
+    expect(credentialPublication).not.toContain('pnpm ');
+    expect(credentialStep?.env?.NPM_CONFIG_IGNORE_SCRIPTS).toBe('true');
+    expect(credentialStep?.env?.NPM_CONFIG_REGISTRY).toBe('https://registry.npmjs.org');
+    expect(credentialPublication).toContain('cd "$RUNNER_TEMP/npm-bootstrap-credential"');
+    expect(freshPreflight).toContain('unique == [$expected]');
+    expect(credentialPublication).toContain('unique == [$expected]');
+    expect(credentialPublication).toContain('repos/$REPOSITORY/git/ref/heads/main');
+    expect(credentialPublication).toContain('.object.sha == $source and .object.sha == $workflow');
+    expect(credentialPublication).toContain('raced-version.json');
+    expect(credentialPublication?.indexOf('publish-main.json')).toBeLessThan(
+      credentialPublication?.indexOf('npm whoami') ?? -1,
+    );
+    expect(credentialPublication?.indexOf('publish-main.json')).toBeLessThan(
+      credentialPublication?.indexOf('npm publish') ?? -1,
+    );
+    expect(recovery).toContain('verify-npm-bootstrap-anchor.mjs provenance');
+    expect(recovery).toContain('verify-npm-bootstrap-anchor.mjs files');
+    expect(recovery).toContain('workflow_run.id');
+    expect(recovery).toContain('actions/workflows/npm-bootstrap.yml');
+    expect(recovery).toContain('.artifactDigest');
+    expect(recovery).toContain('sha256sum "$RUNNER_TEMP/bootstrap-anchor.zip"');
+    expect(recovery?.indexOf('bootstrap-anchor.zip')).toBeLessThan(
+      recovery?.indexOf('unzip -q') ?? -1,
+    );
+    expect(build).not.toContain('$RUNNER_TEMP/bootstrap/dist-tags-before.err');
+    expect(candidateGate).toContain('git fetch --no-tags origin main');
+    expect(candidateGate).toContain('[[ "$(git rev-parse origin/main)" == "$SOURCE_SHA" ]]');
+    const existingVersionProbe = candidateGate?.indexOf('existing-version.raw.json') ?? -1;
+    const exactMainCheck = candidateGate?.indexOf('git rev-parse origin/main') ?? -1;
+    expect(existingVersionProbe).toBeGreaterThanOrEqual(0);
+    expect(existingVersionProbe).toBeLessThan(exactMainCheck);
+    expect(publicState).toContain('verify-npm-bootstrap-state.mjs');
+    expect(publicStateStep?.env ?? {}).not.toHaveProperty('NODE_AUTH_TOKEN');
+    expect(
+      allRun.match(/verify-npm-bootstrap-state\.mjs normalize/gu)?.length ?? 0,
+    ).toBeGreaterThanOrEqual(3);
+    expect(registryVerification).toContain('registry-metadata.raw.json');
+    expect(allRun).toContain('sha256sum --check SHA256SUMS');
+    expect(allRun).toContain('.name == "scriptspect" and .version == $version');
+    expect(verify).toContain('canonical-tree.mjs digest --tarball');
+    expect(prepare).toMatch(/sha256sum "\$TARBALL_BASENAME" > SHA256SUMS/);
+    expect(prepare).not.toMatch(/sha256sum "\$TARBALL" > .*SHA256SUMS/);
+    expect(publish).not.toMatch(/npm publish[^\n]*0\.1\.0/);
     expect(source('release.yml')).not.toContain('NPM_BOOTSTRAP_TOKEN');
   });
 });

--- a/tests/workflows/ci-policy.test.ts
+++ b/tests/workflows/ci-policy.test.ts
@@ -156,6 +156,7 @@ describe('reproducible CI', () => {
 
   it('enforces 90 percent coverage and generated-file parity', () => {
     const ci = workflow('ci.yml');
+    expect(ci.jobs?.generated?.permissions).toEqual({ checks: 'read', contents: 'read' });
     const qualitySteps = ci.jobs?.quality?.steps ?? [];
     const qualityRun = qualitySteps.map((step) => step.run ?? '').join('\n');
     expect(qualityRun).toContain('--coverage');
@@ -167,6 +168,7 @@ describe('reproducible CI', () => {
     const generatedRun = (ci.jobs?.generated?.steps ?? []).map((step) => step.run ?? '').join('\n');
     expect(generatedRun).toContain('generate-schemas.ts');
     expect(generatedRun).toContain('generate-readme-demo.ts');
+    expect(generatedRun).toContain('verify-readme-release-evidence.ts');
     expect(generatedRun).toContain('check-readme-parity.ts');
     expect(generatedRun).not.toContain('generate-readme-status.ts');
     expect(generatedRun).toContain('docs/readme-status.json');
@@ -183,10 +185,10 @@ describe('reproducible CI', () => {
       'terminal.txt',
       'fix.patch',
       'package.after.json',
-      'terminal.svg',
     ]) {
       expect(generatedRun).toContain(pinnedAsset);
     }
+    expect(generatedRun).not.toContain('terminal.svg');
     expect(generatedRun).toContain('docs/validation/readme-action-evidence.json');
     expect(generatedRun).toContain('git diff --quiet "$STATUS_COMMIT" HEAD --');
     expect(generatedRun).not.toContain('git diff-tree');
@@ -212,6 +214,14 @@ describe('reproducible CI', () => {
       step.uses?.startsWith('actions/checkout@'),
     );
     expect(generatedCheckout?.with?.['fetch-depth']).toBe(0);
+    const generatedCommand = (ci.jobs?.generated?.steps ?? []).find((step) =>
+      step.run?.includes('verify-readme-release-evidence.ts'),
+    );
+    expect(generatedCommand?.env?.GITHUB_TOKEN).toBe(`\${{ github.token }}`);
+
+    const paritySource = readFileSync(join(root, 'tools/check-readme-parity.ts'), 'utf8');
+    expect(paritySource).not.toContain("execFileSync('git'");
+    expect(paritySource).not.toContain("spawnSync('git'");
 
     const qualityBuildIndex = qualitySteps.findIndex((step) => step.run === 'pnpm build');
     const qualityCoverageIndex = qualitySteps.findIndex((step) => step.run?.includes('--coverage'));

--- a/tools/check-readme-parity.ts
+++ b/tools/check-readme-parity.ts
@@ -116,7 +116,7 @@ if (status.releaseState === 'pre-release') {
   }
 } else if (status.releaseState === 'published') {
   const escapedPackage = status.packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const escapedVersion = status.packageVersion.replace(/\./g, '\\.');
+  const escapedVersion = status.packageVersion.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   for (const homepage of [english, chinese]) {
     if (homepage.includes('Evaluate from source (pre-release)')) {
       fail('published homepage still contains the pre-release evaluation block');

--- a/tools/check-readme-parity.ts
+++ b/tools/check-readme-parity.ts
@@ -1,10 +1,30 @@
+import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
-const englishPath = resolve(root, 'README.md');
-const chinesePath = resolve(root, 'README.zh-CN.md');
+const paths = {
+  status: resolve(root, 'docs/readme-status.json'),
+  english: resolve(root, 'README.md'),
+  chinese: resolve(root, 'README.zh-CN.md'),
+};
+for (let index = 2; index < process.argv.length; index += 1) {
+  const argument = process.argv[index];
+  if (argument !== '--status' && argument !== '--english' && argument !== '--chinese') {
+    throw new Error(`README parity: unknown option ${argument ?? ''}`);
+  }
+  const value = process.argv[index + 1];
+  if (value === undefined || value.trim() === '') {
+    throw new Error(`README parity: ${argument} needs a path`);
+  }
+  if (argument === '--status') paths.status = resolve(value);
+  if (argument === '--english') paths.english = resolve(value);
+  if (argument === '--chinese') paths.chinese = resolve(value);
+  index += 1;
+}
+const englishPath = paths.english;
+const chinesePath = paths.chinese;
 const english = readFileSync(englishPath, 'utf8');
 const chinese = readFileSync(chinesePath, 'utf8');
 
@@ -12,12 +32,8 @@ function fail(message: string): never {
   throw new Error(`README parity: ${message}`);
 }
 
-function setOf(values: Iterable<string>): string[] {
-  return [...new Set(values)].sort();
-}
-
 function captureAll(text: string, expression: RegExp): string[] {
-  return setOf([...text.matchAll(expression)].map((match) => match[1] ?? match[0]));
+  return [...text.matchAll(expression)].map((match) => match[1] ?? match[0]).sort();
 }
 
 function fencedBlocks(text: string): string[] {
@@ -30,13 +46,13 @@ function equalField(name: string, extractor: (text: string) => string[]): void {
   if (JSON.stringify(left) !== JSON.stringify(right)) fail(`${name} differ between languages`);
 }
 
-function localTargets(markdown: string, source: string): string[] {
+function localTargets(markdown: string): string[] {
   const targets = captureAll(markdown, /!?\[[^\]]*\]\(([^)]+)\)/g);
   for (const target of targets) {
     if (/^(?:https?:|mailto:|#)/.test(target)) continue;
     const clean = target.split('#', 1)[0] ?? '';
     if (clean.length === 0) continue;
-    if (!existsSync(resolve(dirname(source), clean))) fail(`missing local target ${target}`);
+    if (!existsSync(resolve(root, clean))) fail(`missing local target ${target}`);
   }
   return targets;
 }
@@ -53,22 +69,77 @@ equalField('URLs', (text) => captureAll(text, /https?:\/\/[^\s)>]+/g));
 equalField('versions', (text) => captureAll(text, /\bv?\d+\.\d+(?:\.\d+)?\b/g));
 equalField('rule IDs', (text) => captureAll(text, /\bPS\d{3}\b/g));
 equalField('demo assets', (text) => captureAll(text, /docs\/assets\/demo\/[\w.-]+/g));
-localTargets(english, englishPath);
-localTargets(chinese, chinesePath);
+localTargets(english);
+localTargets(chinese);
 
-const status = JSON.parse(readFileSync(resolve(root, 'docs/readme-status.json'), 'utf8')) as {
+const status = JSON.parse(readFileSync(paths.status, 'utf8')) as {
   releaseState: string;
+  packageName: string;
+  packageVersion: string;
+  sourceCommit: string;
 };
-if (status.releaseState !== 'pre-release') fail(`unsupported release state ${status.releaseState}`);
-for (const homepage of [english, chinese]) {
-  if (!homepage.includes('Evaluate from source (pre-release)'))
-    fail('missing pre-release evaluation block');
-  if (fencedBlocks(homepage).some((block) => /\bnpx\s+scriptspect\b/.test(block))) {
-    fail('unpublished npx command is present');
+if (!/^[0-9a-f]{40}$/u.test(status.sourceCommit)) fail('source commit is not an exact SHA');
+const renderCheck = spawnSync(
+  process.execPath,
+  [
+    resolve(root, 'node_modules/tsx/dist/cli.mjs'),
+    resolve(root, 'tools/render-readme-state.ts'),
+    '--status',
+    paths.status,
+    '--english',
+    englishPath,
+    '--chinese',
+    chinesePath,
+    '--check',
+  ],
+  { cwd: root, encoding: 'utf8' },
+);
+if (renderCheck.status !== 0) {
+  fail(renderCheck.stderr.trim() || renderCheck.stdout.trim() || 'homepage state render failed');
+}
+
+if (status.releaseState === 'pre-release') {
+  for (const homepage of [english, chinese]) {
+    if (!homepage.includes('Evaluate from source (pre-release)')) {
+      fail('missing pre-release evaluation block');
+    }
+    if (
+      fencedBlocks(homepage).some((block) =>
+        /\b(?:npx\s+(?:--yes\s+)?scriptspect|pnpm\s+dlx\s+scriptspect)@?/u.test(block),
+      )
+    ) {
+      fail('unpublished package command is present');
+    }
+    if (fencedBlocks(homepage).some((block) => /Tom409114\/scriptspect@v0\.1\b/.test(block))) {
+      fail('nonexistent Action tag is present');
+    }
   }
-  if (fencedBlocks(homepage).some((block) => /Tom409114\/scriptspect@v0\.1\b/.test(block))) {
-    fail('nonexistent Action tag is present');
+} else if (status.releaseState === 'published') {
+  const escapedPackage = status.packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const escapedVersion = status.packageVersion.replace(/\./g, '\\.');
+  for (const homepage of [english, chinese]) {
+    if (homepage.includes('Evaluate from source (pre-release)')) {
+      fail('published homepage still contains the pre-release evaluation block');
+    }
+    if (
+      !fencedBlocks(homepage).some((block) =>
+        new RegExp(`\\bnpx\\s+--yes\\s+${escapedPackage}@${escapedVersion}\\s+\\.`, 'u').test(
+          block,
+        ),
+      )
+    ) {
+      fail('published homepage is missing the exact npm quick start');
+    }
+    if (
+      !fencedBlocks(homepage).some((block) =>
+        block.includes(`uses: Tom409114/scriptspect@v${status.packageVersion}`),
+      )
+    ) {
+      fail('published homepage is missing the immutable Action release tag');
+    }
   }
+} else {
+  fail(`unsupported release state ${status.releaseState}`);
 }
 
 console.log('README parity check passed');

--- a/tools/generate-readme-demo.ts
+++ b/tools/generate-readme-demo.ts
@@ -107,7 +107,7 @@ function terminalSvg(text: string): string {
     .join('\n');
   return `<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-labelledby="title desc">
-  <title id="title">ScriptSpect pre-release demo output</title>
+  <title id="title">ScriptSpect demo output</title>
   <desc id="desc">Terminal output from checking the README demo fixture. The selectable text version is available beside this image.</desc>
   <style>.terminal { fill: #0d1117; } .bar { fill: #161b22; } .terminal-line { fill: #c9d1d9; font: 16px ui-monospace, SFMono-Regular, Consolas, monospace; white-space: pre; } .terminal-command { fill: #7ee787; } .terminal-section { fill: #79c0ff; font-weight: 600; } .terminal-error { fill: #ff7b72; font-weight: 600; } .terminal-advisory { fill: #d29922; font-weight: 600; } .terminal-summary { fill: #8b949e; }</style>
   <rect class="terminal" width="100%" height="100%" rx="12"/>

--- a/tools/generate-readme-status.ts
+++ b/tools/generate-readme-status.ts
@@ -1,16 +1,42 @@
 import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  validateReadmeReleaseReceipt,
+  validateReceiptAgainstStatus,
+} from './readme-release-receipt.js';
+import { canonicalJsonDigest } from './release/release-state.mjs';
 
 const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')) as {
   name: string;
   version: string;
 };
-const requestedCommit = process.argv[2] ?? process.env.SCRIPTSPECT_SOURCE_COMMIT;
+const arguments_ = process.argv.slice(2);
+const requestedCommit = arguments_[0] ?? process.env.SCRIPTSPECT_SOURCE_COMMIT;
 if (requestedCommit === undefined || requestedCommit.trim() === '') {
   throw new Error('pass an explicit reviewed source commit');
+}
+let published = false;
+let receiptPath: string | undefined;
+for (let index = 1; index < arguments_.length; index += 1) {
+  const argument = arguments_[index];
+  if (argument === '--published') {
+    if (published) throw new Error('pass --published at most once');
+    published = true;
+    continue;
+  }
+  if (argument === '--receipt') {
+    if (receiptPath !== undefined) throw new Error('pass --receipt at most once');
+    receiptPath = arguments_[index + 1];
+    if (receiptPath === undefined || receiptPath.trim() === '') {
+      throw new Error('--receipt needs a path');
+    }
+    index += 1;
+    continue;
+  }
+  throw new Error(`unknown README state option ${argument ?? ''}`);
 }
 const sourceCommit = execFileSync('git', ['rev-parse', `${requestedCommit}^{commit}`], {
   cwd: root,
@@ -41,9 +67,17 @@ try {
 } catch {
   throw new Error('source commit must match HEAD for runtime, package, and Action files');
 }
-const releaseState = pkg.version === '0.0.0' ? 'pre-release' : 'published';
-
-const manifest = {
+const releaseState = published ? 'published' : 'pre-release';
+const manifest: {
+  schemaVersion: number;
+  releaseState: 'pre-release' | 'published';
+  packageName: string;
+  packageVersion: string;
+  sourceCommit: string;
+  nodeMajor: number;
+  repository: string;
+  releaseEvidence?: { receiptPath: string; digest: string };
+} = {
   schemaVersion: 1,
   releaseState,
   packageName: pkg.name,
@@ -52,6 +86,42 @@ const manifest = {
   nodeMajor: 22,
   repository: 'https://github.com/Tom409114/scriptspect',
 };
+if (releaseState === 'published') {
+  if (pkg.version === '0.0.0') {
+    throw new Error('published README state requires a nonzero released version');
+  }
+  if (receiptPath === undefined) {
+    throw new Error('published README state requires --receipt terminal evidence');
+  }
+  const tagCommit = execFileSync('git', ['rev-parse', `v${pkg.version}^{commit}`], {
+    cwd: root,
+    encoding: 'utf8',
+  }).trim();
+  if (tagCommit !== sourceCommit) {
+    throw new Error('published README state must use the exact immutable release tag commit');
+  }
+  const absoluteReceiptPath = resolve(root, receiptPath);
+  const statusDirectory = resolve(root, 'docs');
+  const expectedDirectory = resolve(statusDirectory, 'validation', 'releases', `v${pkg.version}`);
+  if (
+    absoluteReceiptPath !== resolve(expectedDirectory, 'readme-release-receipt.json') ||
+    !absoluteReceiptPath.startsWith(`${expectedDirectory}${sep}`)
+  ) {
+    throw new Error(
+      `published receipt must be docs/validation/releases/v${pkg.version}/readme-release-receipt.json`,
+    );
+  }
+  const receipt = validateReadmeReleaseReceipt(
+    JSON.parse(readFileSync(absoluteReceiptPath, 'utf8')),
+  );
+  manifest.releaseEvidence = {
+    receiptPath: relative(statusDirectory, absoluteReceiptPath).replaceAll('\\', '/'),
+    digest: canonicalJsonDigest(receipt),
+  };
+  validateReceiptAgainstStatus(receipt, manifest);
+} else if (receiptPath !== undefined) {
+  throw new Error('--receipt is only valid together with --published');
+}
 
 writeFileSync(resolve(root, 'docs/readme-status.json'), `${JSON.stringify(manifest, null, 2)}\n`);
 console.log(`README status generated (${releaseState})`);

--- a/tools/readme-release-receipt.ts
+++ b/tools/readme-release-receipt.ts
@@ -1,0 +1,155 @@
+import {
+  canonicalJsonDigest,
+  type FinalVerification,
+  verifyFinalIdempotency,
+} from './release/release-state.mjs';
+
+export interface ReadmeReleaseReceipt {
+  schemaVersion: 'scriptspect-readme-release-receipt/v1';
+  repository: 'https://github.com/Tom409114/scriptspect';
+  intentCheckRunId: number;
+  finalVerificationAssetId: number;
+  finalVerificationDigest: string;
+  publishRunId: number;
+  finalVerification: FinalVerification;
+}
+
+export interface ReadmeReleaseStatus {
+  releaseState: 'pre-release' | 'published';
+  packageName: string;
+  packageVersion: string;
+  sourceCommit: string;
+  repository: string;
+  releaseEvidence?: {
+    receiptPath: string;
+    digest: string;
+  };
+}
+
+const receiptKeys = [
+  'schemaVersion',
+  'repository',
+  'intentCheckRunId',
+  'finalVerificationAssetId',
+  'finalVerificationDigest',
+  'publishRunId',
+  'finalVerification',
+] as const;
+const receiptSchema = 'scriptspect-readme-release-receipt/v1';
+const scriptspectRepository = 'https://github.com/Tom409114/scriptspect';
+
+function exactReceiptObject(value: unknown): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('README release receipt must be an object with exact keys');
+  }
+  const actual = Object.keys(value).sort();
+  const expected = [...receiptKeys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    throw new Error('README release receipt must contain exact keys');
+  }
+  return value as Record<string, unknown>;
+}
+
+function objectRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`README release receipt ${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function positiveInteger(value: unknown, field: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+    throw new Error(`README release receipt ${field} must be a positive integer`);
+  }
+  return value as number;
+}
+
+function sha256(value: unknown, field: string): string {
+  if (typeof value !== 'string' || !/^[0-9a-f]{64}$/u.test(value)) {
+    throw new Error(`README release receipt ${field} must be a SHA-256 digest`);
+  }
+  return value;
+}
+
+function releaseEvidence(value: unknown): { receiptPath: string; digest: string } {
+  const input = objectRecord(value, 'status releaseEvidence');
+  const keys = Object.keys(input).sort();
+  if (keys.length !== 2 || keys[0] !== 'digest' || keys[1] !== 'receiptPath') {
+    throw new Error('README release receipt status releaseEvidence must contain exact keys');
+  }
+  if (
+    typeof input.receiptPath !== 'string' ||
+    input.receiptPath.trim() === '' ||
+    input.receiptPath.includes('\\') ||
+    input.receiptPath.startsWith('/') ||
+    /^[A-Za-z]:/u.test(input.receiptPath) ||
+    input.receiptPath.split('/').some((part) => part === '' || part === '.' || part === '..')
+  ) {
+    throw new Error('README release receipt status receiptPath must be repository-relative');
+  }
+  return {
+    receiptPath: input.receiptPath,
+    digest: sha256(input.digest, 'status releaseEvidence digest'),
+  };
+}
+
+export function validateReadmeReleaseReceipt(value: unknown): ReadmeReleaseReceipt {
+  const input = exactReceiptObject(value);
+  if (input.schemaVersion !== receiptSchema) {
+    throw new Error('README release receipt schemaVersion is unsupported');
+  }
+  if (input.repository !== scriptspectRepository) {
+    throw new Error('README release receipt repository is unexpected');
+  }
+  const finalVerification = verifyFinalIdempotency(null, input.finalVerification).verification;
+  const finalVerificationDigest = sha256(input.finalVerificationDigest, 'finalVerificationDigest');
+  if (finalVerificationDigest !== canonicalJsonDigest(finalVerification)) {
+    throw new Error('README release receipt finalVerificationDigest does not match');
+  }
+  return {
+    schemaVersion: receiptSchema,
+    repository: scriptspectRepository,
+    intentCheckRunId: positiveInteger(input.intentCheckRunId, 'intentCheckRunId'),
+    finalVerificationAssetId: positiveInteger(
+      input.finalVerificationAssetId,
+      'finalVerificationAssetId',
+    ),
+    finalVerificationDigest,
+    publishRunId: positiveInteger(input.publishRunId, 'publishRunId'),
+    finalVerification,
+  };
+}
+
+export function validateReceiptAgainstStatus(
+  receipt: unknown,
+  status: unknown,
+): ReadmeReleaseReceipt {
+  const input = objectRecord(status, 'status');
+  if (input.releaseState === 'pre-release') {
+    throw new Error('README release receipt is not allowed for pre-release status');
+  }
+  if (input.releaseState !== 'published') {
+    throw new Error('README release receipt status releaseState is unsupported');
+  }
+  const normalized = validateReadmeReleaseReceipt(receipt);
+  if (input.packageName !== 'scriptspect') {
+    throw new Error('README release receipt status packageName does not match');
+  }
+  if (input.packageVersion !== normalized.finalVerification.version) {
+    throw new Error('README release receipt status packageVersion does not match');
+  }
+  if (input.sourceCommit !== normalized.finalVerification.commit) {
+    throw new Error('README release receipt status sourceCommit does not match');
+  }
+  if (input.repository !== normalized.repository) {
+    throw new Error('README release receipt status repository does not match');
+  }
+  if (normalized.finalVerification.tag !== `v${input.packageVersion}`) {
+    throw new Error('README release receipt status tag does not match');
+  }
+  const evidence = releaseEvidence(input.releaseEvidence);
+  if (evidence.digest !== canonicalJsonDigest(normalized)) {
+    throw new Error('README release receipt status releaseEvidence digest does not match');
+  }
+  return normalized;
+}

--- a/tools/release/generate-package-readmes.mjs
+++ b/tools/release/generate-package-readmes.mjs
@@ -1,0 +1,215 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+function fail(message) {
+  throw new Error(`package README: ${message}`);
+}
+
+function parseArguments(arguments_) {
+  const allowed = new Set(['--version', '--source-commit', '--channel', '--english', '--chinese']);
+  const values = new Map();
+  for (let index = 0; index < arguments_.length; index += 2) {
+    const name = arguments_[index];
+    const value = arguments_[index + 1];
+    if (!allowed.has(name)) fail(`unknown option ${name ?? ''}`);
+    if (value === undefined || value.startsWith('--')) fail(`${name} needs one value`);
+    if (values.has(name)) fail(`${name} may be passed only once`);
+    values.set(name, value);
+  }
+  for (const name of allowed) {
+    if (!values.has(name)) fail(`${name} is required`);
+  }
+  return {
+    version: values.get('--version'),
+    sourceCommit: values.get('--source-commit'),
+    channel: values.get('--channel'),
+    english: resolve(values.get('--english')),
+    chinese: resolve(values.get('--chinese')),
+  };
+}
+
+function validate(options) {
+  const semver =
+    /^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/u;
+  if (!semver.test(options.version)) fail('version must be exact SemVer without build metadata');
+  if (!/^[0-9a-f]{40}$/u.test(options.sourceCommit)) {
+    fail('source commit must be an exact lowercase 40-character SHA');
+  }
+  if (!['stable', 'bootstrap'].includes(options.channel)) fail('invalid channel');
+  if (
+    options.channel === 'stable' &&
+    (options.version === '0.0.0' || options.version.includes('-'))
+  ) {
+    fail('stable channel needs a nonzero stable version');
+  }
+  if (
+    options.channel === 'bootstrap' &&
+    !/^0\.0\.0-bootstrap\.(?:0|[1-9][0-9]*)$/u.test(options.version)
+  ) {
+    fail('bootstrap channel needs version 0.0.0-bootstrap.N');
+  }
+  if (options.english === options.chinese) fail('output paths must differ');
+}
+
+function context(version, sourceCommit) {
+  return {
+    repository: 'https://github.com/Tom409114/scriptspect',
+    raw: `https://raw.githubusercontent.com/Tom409114/scriptspect/${sourceCommit}`,
+    unpkg: `https://unpkg.com/scriptspect@${version}`,
+  };
+}
+
+function stableEnglish(version, sourceCommit) {
+  const { repository, raw, unpkg } = context(version, sourceCommit);
+  return `[English](${unpkg}/README.md) | [简体中文](${unpkg}/README.zh-CN.md)
+
+<p align="center"><img src="${raw}/docs/assets/brand/hero.svg" width="100%" alt="ScriptSpect finds cross-shell portability problems before package scripts run"></p>
+
+> **Package edition:** \`scriptspect@${version}\` · source \`${sourceCommit}\`
+
+ScriptSpect statically checks \`package.json\` scripts without running them. It pinpoints constructs that change meaning across POSIX shell, Windows cmd, and optional PowerShell targets.
+
+## Run in 30 seconds
+
+Requires Node.js 22 or newer. Run this exact version without a global install:
+
+\`\`\`bash
+npx --yes scriptspect@${version} .
+pnpm dlx scriptspect@${version} .
+\`\`\`
+
+Findings exit \`1\`; a clean scan exits \`0\`; invalid input, configuration, or I/O exits \`2\`. Start with \`--fix-dry-run\` before applying a reviewed fix.
+
+## Before, result, and after
+
+\`\`\`json
+{"scripts":{"build":"NODE_ENV=production vite build","clean":"rm -rf dist"}}
+\`\`\`
+
+![Real ScriptSpect output generated from the versioned demo fixture](${raw}/docs/assets/demo/terminal.svg)
+
+\`\`\`diff
+-"build": "NODE_ENV=production vite build"
+-"clean": "rm -rf dist"
++"build": "cross-env NODE_ENV=production vite build"
++"clean": "rimraf dist"
+\`\`\`
+
+The demo uses dependencies already declared by the fixture. Ambiguous changes remain manual; ScriptSpect never installs dependencies or rewrites a lockfile.
+
+## GitHub Actions
+
+\`\`\`yaml
+- uses: Tom409114/scriptspect@v${version}
+  with:
+    path: .
+\`\`\`
+
+For the strongest supply-chain pin, replace \`v${version}\` with \`${sourceCommit}\`.
+
+[Rules](${repository}/tree/${sourceCommit}/docs/rules) · [Config schema](${repository}/blob/${sourceCommit}/schema/config.schema.json) · [Report a vulnerability](${repository}/security/advisories/new) · [Source](${repository}/tree/${sourceCommit})
+`;
+}
+
+function stableChinese(version, sourceCommit) {
+  const { repository, raw, unpkg } = context(version, sourceCommit);
+  return `[English](${unpkg}/README.md) | [简体中文](${unpkg}/README.zh-CN.md)
+
+<p align="center"><img src="${raw}/docs/assets/brand/hero.svg" width="100%" alt="ScriptSpect 在 package scripts 运行前发现跨 shell 可移植性问题"></p>
+
+> **Package 版本：** \`scriptspect@${version}\` · source \`${sourceCommit}\`
+
+ScriptSpect 不运行 scripts，只对 \`package.json\` 做静态分析。它会精确指出在 POSIX shell、Windows cmd 与可选 PowerShell target 之间含义不同的结构。
+
+## 30 秒开始
+
+需要 Node.js 22 或更高版本。无需全局安装，直接运行这个准确版本：
+
+\`\`\`bash
+npx --yes scriptspect@${version} .
+pnpm dlx scriptspect@${version} .
+\`\`\`
+
+存在 finding 时退出 \`1\`；clean scan 退出 \`0\`；无效输入、配置或 I/O 退出 \`2\`。应用经审查的修复前，请先使用 \`--fix-dry-run\`。
+
+## 修复前、分析结果与修复后
+
+\`\`\`json
+{"scripts":{"build":"NODE_ENV=production vite build","clean":"rm -rf dist"}}
+\`\`\`
+
+![由版本化 demo fixture 生成的真实 ScriptSpect 输出](${raw}/docs/assets/demo/terminal.svg)
+
+\`\`\`diff
+-"build": "NODE_ENV=production vite build"
+-"clean": "rm -rf dist"
++"build": "cross-env NODE_ENV=production vite build"
++"clean": "rimraf dist"
+\`\`\`
+
+这个 demo 只使用 fixture 已声明的 dependencies。歧义修改始终保持 manual；ScriptSpect 不会安装 dependencies，也不会改写 lockfile。
+
+## GitHub Actions
+
+\`\`\`yaml
+- uses: Tom409114/scriptspect@v${version}
+  with:
+    path: .
+\`\`\`
+
+若要获得最严格的供应链固定，请把 \`v${version}\` 替换为 \`${sourceCommit}\`。
+
+[规则列表](${repository}/tree/${sourceCommit}/docs/rules) · [配置 Schema](${repository}/blob/${sourceCommit}/schema/config.schema.json) · [报告漏洞](${repository}/security/advisories/new) · [源码](${repository}/tree/${sourceCommit})
+`;
+}
+
+function bootstrapEnglish(version, sourceCommit) {
+  const { repository, raw, unpkg } = context(version, sourceCommit);
+  return `[English](${unpkg}/README.md) | [简体中文](${unpkg}/README.zh-CN.md)
+
+<p align="center"><img src="${raw}/docs/assets/brand/hero.svg" width="100%" alt="ScriptSpect package-script portability analyzer"></p>
+
+# ScriptSpect npm bootstrap artifact
+
+\`scriptspect@${version}\` is a one-time npm ownership and integrity bootstrap artifact. It is **not a supported stable release**, does not move the \`latest\` dist-tag, and must not be used as a stable GitHub Action reference.
+
+The bootstrap workflow checks its retained candidate, registry bytes, package tree, CLI, schemas, and bundled Action against source commit \`${sourceCommit}\`.
+
+[Project homepage](${repository}/tree/${sourceCommit}) · [Bootstrap workflow policy](${repository}/blob/${sourceCommit}/.github/workflows/npm-bootstrap.yml)
+`;
+}
+
+function bootstrapChinese(version, sourceCommit) {
+  const { repository, raw, unpkg } = context(version, sourceCommit);
+  return `[English](${unpkg}/README.md) | [简体中文](${unpkg}/README.zh-CN.md)
+
+<p align="center"><img src="${raw}/docs/assets/brand/hero.svg" width="100%" alt="ScriptSpect package script 可移植性分析器"></p>
+
+# ScriptSpect npm bootstrap artifact
+
+\`scriptspect@${version}\` 是一次性的 npm ownership 与 integrity bootstrap artifact。它**不是受支持的 stable release**，不会移动 \`latest\` dist-tag，也不能作为稳定 GitHub Action reference 使用。
+
+bootstrap workflow 会把 retained candidate、registry bytes、package tree、CLI、schemas 与 bundled Action 对照 source commit \`${sourceCommit}\` 进行检查。
+
+[项目主页](${repository}/tree/${sourceCommit}) · [Bootstrap workflow policy](${repository}/blob/${sourceCommit}/.github/workflows/npm-bootstrap.yml)
+`;
+}
+
+const options = parseArguments(process.argv.slice(2));
+validate(options);
+const english =
+  options.channel === 'stable'
+    ? stableEnglish(options.version, options.sourceCommit)
+    : bootstrapEnglish(options.version, options.sourceCommit);
+const chinese =
+  options.channel === 'stable'
+    ? stableChinese(options.version, options.sourceCommit)
+    : bootstrapChinese(options.version, options.sourceCommit);
+for (const [path, content] of [
+  [options.english, english],
+  [options.chinese, chinese],
+]) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, 'utf8');
+}
+console.log(`package READMEs generated (${options.channel} ${options.version})`);

--- a/tools/release/verify-npm-bootstrap-anchor.mjs
+++ b/tools/release/verify-npm-bootstrap-anchor.mjs
@@ -1,0 +1,201 @@
+import { createHash } from 'node:crypto';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+function fail(message) {
+  throw new Error(`npm bootstrap anchor: ${message}`);
+}
+
+function parseOptions(args, names) {
+  const allowed = new Set(names.map((name) => `--${name}`));
+  const values = new Map();
+  for (let index = 0; index < args.length; index += 2) {
+    const name = args[index];
+    const value = args[index + 1];
+    if (!allowed.has(name)) fail(`unknown option ${name ?? ''}`);
+    if (value === undefined || value.trim() === '') fail(`${name} needs a value`);
+    if (values.has(name)) fail(`duplicate option ${name}`);
+    values.set(name, value);
+  }
+  for (const name of allowed) {
+    if (!values.has(name)) fail(`missing option ${name}`);
+  }
+  return Object.fromEntries([...values].map(([name, value]) => [name.slice(2), value]));
+}
+
+function readJson(path, label) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    fail(`${label} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function object(value, label) {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+  return value;
+}
+
+function positiveInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value <= 0) fail(`${label} must be a positive integer`);
+  return value;
+}
+
+function equal(actual, expected, label) {
+  if (actual !== expected) fail(`${label} does not match the trusted bootstrap run`);
+}
+
+function exactKeys(value, expected, label) {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(wanted)) fail(`${label} fields are invalid`);
+}
+
+function sha256(path) {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+function verifyProvenance(args) {
+  const options = parseOptions(args, [
+    'artifacts',
+    'run',
+    'workflow',
+    'repository',
+    'artifact-name',
+    'repository-name',
+    'source-sha',
+  ]);
+  if (!/^[0-9a-f]{40}$/u.test(options['source-sha'])) fail('source SHA is invalid');
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(options['repository-name'])) {
+    fail('repository name is invalid');
+  }
+
+  const artifacts = object(readJson(options.artifacts, 'artifacts'), 'artifacts');
+  const run = object(readJson(options.run, 'workflow run'), 'workflow run');
+  const workflow = object(readJson(options.workflow, 'workflow'), 'workflow');
+  const repository = object(readJson(options.repository, 'repository'), 'repository');
+  const repositoryId = positiveInteger(repository.id, 'repository id');
+  equal(repository.full_name, options['repository-name'], 'repository name');
+  const workflowId = positiveInteger(workflow.id, 'workflow id');
+  equal(workflow.path, '.github/workflows/npm-bootstrap.yml', 'workflow path');
+
+  if (!Array.isArray(artifacts.artifacts)) fail('artifacts list is missing');
+  const matches = artifacts.artifacts.filter(
+    (entry) => entry?.expired === false && entry?.name === options['artifact-name'],
+  );
+  if (matches.length !== 1) fail('expected exactly one retained matching artifact');
+  const artifact = object(matches[0], 'artifact');
+  const artifactId = positiveInteger(artifact.id, 'artifact id');
+  if (typeof artifact.digest !== 'string' || !/^sha256:[0-9a-f]{64}$/u.test(artifact.digest)) {
+    fail('artifact digest is invalid');
+  }
+  const artifactRun = object(artifact.workflow_run, 'artifact workflow run');
+  const runId = positiveInteger(run.id, 'run id');
+  equal(positiveInteger(artifactRun.id, 'artifact run id'), runId, 'artifact run id');
+  equal(artifactRun.repository_id, repositoryId, 'artifact repository id');
+  equal(artifactRun.head_repository_id, repositoryId, 'artifact head repository id');
+  equal(artifactRun.head_branch, 'main', 'artifact head branch');
+  equal(artifactRun.head_sha, options['source-sha'], 'artifact head SHA');
+
+  equal(run.event, 'workflow_dispatch', 'workflow event');
+  equal(run.head_branch, 'main', 'workflow run branch');
+  equal(run.head_sha, options['source-sha'], 'workflow run head SHA');
+  equal(run.path, '.github/workflows/npm-bootstrap.yml', 'workflow run path');
+  equal(run.workflow_id, workflowId, 'workflow id');
+  const runRepository = object(run.repository, 'run repository');
+  const runHeadRepository = object(run.head_repository, 'run head repository');
+  equal(runRepository.id, repositoryId, 'run repository id');
+  equal(runRepository.full_name, options['repository-name'], 'run repository name');
+  equal(runHeadRepository.id, repositoryId, 'run head repository id');
+  equal(runHeadRepository.full_name, options['repository-name'], 'run head repository name');
+
+  return {
+    artifactId,
+    artifactDigest: artifact.digest,
+    runId,
+    sourceCommit: options['source-sha'],
+    workflowId,
+  };
+}
+
+function verifyFiles(args) {
+  const options = parseOptions(args, ['directory', 'source-sha', 'version']);
+  if (!/^[0-9a-f]{40}$/u.test(options['source-sha'])) fail('source SHA is invalid');
+  if (!/^0\.0\.0-bootstrap\.(?:0|[1-9][0-9]*)$/u.test(options.version)) {
+    fail('version must be a distinct bootstrap prerelease');
+  }
+  const tarballBasename = `scriptspect-${options.version}.tgz`;
+  const expectedFiles = [
+    'SHA256SUMS',
+    'bootstrap-anchor.json',
+    'dist-tags-before.json',
+    tarballBasename,
+  ].sort();
+  const entries = readdirSync(options.directory, { withFileTypes: true });
+  if (entries.some((entry) => !entry.isFile())) fail('anchor contains a non-file entry');
+  if (JSON.stringify(entries.map((entry) => entry.name).sort()) !== JSON.stringify(expectedFiles)) {
+    fail('anchor must contain exactly one expected tarball and its three manifests');
+  }
+
+  const anchor = object(
+    readJson(join(options.directory, 'bootstrap-anchor.json'), 'bootstrap anchor'),
+    'bootstrap anchor',
+  );
+  exactKeys(
+    anchor,
+    ['schemaVersion', 'sourceCommit', 'version', 'tarball', 'distTagsBeforeDigest'],
+    'bootstrap anchor',
+  );
+  equal(anchor.schemaVersion, 'scriptspect-bootstrap-anchor/v1', 'anchor schema version');
+  equal(anchor.sourceCommit, options['source-sha'], 'anchor source commit');
+  equal(anchor.version, options.version, 'anchor version');
+  const tarball = object(anchor.tarball, 'anchor tarball');
+  exactKeys(tarball, ['basename', 'sha256'], 'anchor tarball');
+  equal(tarball.basename, tarballBasename, 'anchor tarball basename');
+  if (typeof tarball.sha256 !== 'string' || !/^[0-9a-f]{64}$/u.test(tarball.sha256)) {
+    fail('anchor tarball SHA-256 is invalid');
+  }
+  if (
+    typeof anchor.distTagsBeforeDigest !== 'string' ||
+    !/^[0-9a-f]{64}$/u.test(anchor.distTagsBeforeDigest)
+  ) {
+    fail('anchor dist-tags digest is invalid');
+  }
+
+  const tarballPath = join(options.directory, tarballBasename);
+  const actualTarballSha = sha256(tarballPath);
+  equal(tarball.sha256, actualTarballSha, 'anchor tarball SHA-256');
+  const sums = readFileSync(join(options.directory, 'SHA256SUMS'), 'utf8');
+  const sumMatch = /^([0-9a-f]{64}) {2}([^\r\n]+)\r?\n$/u.exec(sums);
+  if (sumMatch === null) fail('SHA256SUMS must contain exactly one text-mode checksum');
+  equal(sumMatch[1], actualTarballSha, 'SHA256SUMS digest');
+  equal(sumMatch[2], tarballBasename, 'SHA256SUMS basename');
+
+  const distTagsPath = join(options.directory, 'dist-tags-before.json');
+  const distTags = readJson(distTagsPath, 'dist-tags before');
+  if (typeof distTags !== 'object' || distTags === null || Array.isArray(distTags)) {
+    fail('dist-tags before must be a normalized JSON object');
+  }
+  for (const [name, version] of Object.entries(distTags)) {
+    if (name.trim() === '' || typeof version !== 'string' || version.trim() === '') {
+      fail('dist-tags before contains an invalid entry');
+    }
+  }
+  equal(anchor.distTagsBeforeDigest, sha256(distTagsPath), 'anchor dist-tags digest');
+
+  return {
+    sourceCommit: options['source-sha'],
+    version: options.version,
+    tarball: { basename: tarballBasename, sha256: actualTarballSha },
+    distTagsBeforeDigest: anchor.distTagsBeforeDigest,
+  };
+}
+
+const [command, ...args] = process.argv.slice(2);
+let result;
+if (command === 'provenance') result = verifyProvenance(args);
+else if (command === 'files') result = verifyFiles(args);
+else fail(`unknown command ${command ?? ''}`);
+console.log(JSON.stringify(result));

--- a/tools/release/verify-npm-bootstrap-state.mjs
+++ b/tools/release/verify-npm-bootstrap-state.mjs
@@ -1,0 +1,158 @@
+import { readFileSync } from 'node:fs';
+
+function fail(message) {
+  throw new Error(`npm bootstrap state: ${message}`);
+}
+
+function parseArguments(args) {
+  const expected = new Set(['--owners', '--owner', '--before', '--after', '--version']);
+  const values = new Map();
+  for (let index = 0; index < args.length; index += 2) {
+    const name = args[index];
+    const value = args[index + 1];
+    if (!expected.has(name)) fail(`unknown option ${name ?? ''}`);
+    if (value === undefined || value.trim() === '') fail(`${name} needs a value`);
+    if (values.has(name)) fail(`duplicate option ${name}`);
+    values.set(name, value);
+  }
+  for (const name of ['--owners', '--owner']) {
+    if (!values.has(name)) fail(`missing option ${name}`);
+  }
+  const stateOptions = ['--before', '--after', '--version'];
+  const stateOptionCount = stateOptions.filter((name) => values.has(name)).length;
+  if (stateOptionCount !== 0 && stateOptionCount !== stateOptions.length) {
+    fail('before, after, and version must be supplied together');
+  }
+  return Object.fromEntries([...values].map(([name, value]) => [name.slice(2), value]));
+}
+
+function readJson(path, label) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    fail(`${label} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function normalizeNpmView(value, type, label) {
+  const normalized = Array.isArray(value) && value.length === 1 ? value[0] : value;
+  if (type === 'string') {
+    if (typeof normalized !== 'string' || normalized.trim() === '') {
+      fail(`${label} must contain one non-empty string result`);
+    }
+    return normalized;
+  }
+  if (
+    type === 'object' &&
+    (typeof normalized !== 'object' || normalized === null || Array.isArray(normalized))
+  ) {
+    fail(`${label} must contain one object result`);
+  }
+  return normalized;
+}
+
+function parseNormalizeArguments(args) {
+  const values = new Map();
+  for (let index = 0; index < args.length; index += 2) {
+    const name = args[index];
+    const value = args[index + 1];
+    if (!['--input', '--type'].includes(name)) fail(`unknown normalize option ${name ?? ''}`);
+    if (value === undefined || value.trim() === '') fail(`${name} needs a value`);
+    if (values.has(name)) fail(`duplicate normalize option ${name}`);
+    values.set(name, value);
+  }
+  if (!values.has('--input') || !values.has('--type')) {
+    fail('normalize requires input and type');
+  }
+  const type = values.get('--type');
+  if (type !== 'string' && type !== 'object') fail('normalize type must be string or object');
+  return { input: values.get('--input'), type };
+}
+
+function maintainerName(value) {
+  if (typeof value === 'string') {
+    const match = /^([^\s<]+)(?:\s|<|$)/u.exec(value.trim());
+    if (match?.[1] !== undefined) return match[1];
+  } else if (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof value.name === 'string' &&
+    value.name.trim() !== ''
+  ) {
+    return value.name.trim();
+  }
+  fail('maintainers contain an unsupported entry');
+}
+
+function maintainerNames(value) {
+  const normalized =
+    Array.isArray(value) && value.length === 1 && Array.isArray(value[0]) ? value[0] : value;
+  const entries = Array.isArray(normalized) ? normalized : [normalized];
+  if (entries.length === 0) fail('maintainers are empty');
+  return [...new Set(entries.map((entry) => maintainerName(entry).toLowerCase()))].sort(
+    (left, right) => left.localeCompare(right),
+  );
+}
+
+function distTags(value, label) {
+  const normalized = normalizeNpmView(value, 'object', `${label} dist-tags`);
+  if (typeof normalized !== 'object' || normalized === null || Array.isArray(normalized)) {
+    fail(`${label} dist-tags must be a JSON object`);
+  }
+  const result = {};
+  for (const [name, version] of Object.entries(normalized)) {
+    if (name.trim() === '' || typeof version !== 'string' || version.trim() === '') {
+      fail(`${label} dist-tags contain an invalid entry`);
+    }
+    result[name] = version;
+  }
+  return result;
+}
+
+const arguments_ = process.argv.slice(2);
+if (arguments_[0] === 'normalize') {
+  const normalizeOptions = parseNormalizeArguments(arguments_.slice(1));
+  const normalized = normalizeNpmView(
+    readJson(normalizeOptions.input, 'npm view output'),
+    normalizeOptions.type,
+    'npm view output',
+  );
+  console.log(normalizeOptions.type === 'string' ? normalized : JSON.stringify(normalized));
+  process.exit(0);
+}
+
+const options = parseArguments(arguments_);
+if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/u.test(options.owner)) fail('owner is invalid');
+
+const owners = maintainerNames(readJson(options.owners, 'maintainers'));
+const expectedOwner = options.owner.toLowerCase();
+if (!owners.includes(expectedOwner)) {
+  fail('authenticated npm owner is not a package maintainer');
+}
+if (owners.length !== 1) fail('package maintainers must contain only the expected npm owner');
+if (options.before === undefined) {
+  console.log(JSON.stringify({ owner: options.owner }));
+} else {
+  if (!/^0\.0\.0-bootstrap\.[0-9]+$/u.test(options.version)) {
+    fail('version must be a distinct bootstrap prerelease');
+  }
+  const before = distTags(readJson(options.before, 'before'), 'before');
+  const after = distTags(readJson(options.after, 'after'), 'after');
+  if (after.bootstrap !== options.version) {
+    fail('bootstrap dist-tag does not match the requested version');
+  }
+  const latestBefore = before.latest ?? null;
+  const latestAfter = after.latest ?? null;
+  if (latestBefore !== latestAfter) fail('latest dist-tag changed during bootstrap');
+
+  console.log(
+    JSON.stringify({
+      owner: options.owner,
+      version: options.version,
+      latestBefore,
+      latestAfter,
+      bootstrap: after.bootstrap,
+    }),
+  );
+}

--- a/tools/render-readme-state.ts
+++ b/tools/render-readme-state.ts
@@ -1,0 +1,438 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, isAbsolute, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  validateReadmeReleaseReceipt,
+  validateReceiptAgainstStatus,
+} from './readme-release-receipt';
+import { canonicalJsonDigest } from './release/release-state.mjs';
+
+type ReleaseState = 'pre-release' | 'published';
+type Locale = 'english' | 'chinese';
+
+interface ReadmeStatus {
+  schemaVersion: number;
+  releaseState: ReleaseState;
+  packageName: string;
+  packageVersion: string;
+  sourceCommit: string;
+  nodeMajor: number;
+  repository: string;
+  releaseEvidence?: {
+    receiptPath: string;
+    digest: string;
+  };
+}
+
+interface Options {
+  status: string;
+  english: string;
+  chinese: string;
+  check: boolean;
+}
+
+const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const defaults: Options = {
+  status: resolve(root, 'docs/readme-status.json'),
+  english: resolve(root, 'README.md'),
+  chinese: resolve(root, 'README.zh-CN.md'),
+  check: false,
+};
+
+function fail(message: string): never {
+  throw new Error(`README state: ${message}`);
+}
+
+function parseOptions(args: string[]): Options {
+  const options = { ...defaults };
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === '--check') {
+      options.check = true;
+      continue;
+    }
+    if (argument !== '--status' && argument !== '--english' && argument !== '--chinese') {
+      fail(`unknown option ${argument ?? ''}`);
+    }
+    const value = args[index + 1];
+    if (value === undefined || value.trim() === '') fail(`${argument} needs a path`);
+    if (argument === '--status') options.status = resolve(value);
+    if (argument === '--english') options.english = resolve(value);
+    if (argument === '--chinese') options.chinese = resolve(value);
+    index += 1;
+  }
+  return options;
+}
+
+function parseStatus(path: string): ReadmeStatus {
+  const value = JSON.parse(readFileSync(path, 'utf8')) as Partial<ReadmeStatus>;
+  if (value.schemaVersion !== 1) fail('unsupported status schema');
+  if (value.releaseState !== 'pre-release' && value.releaseState !== 'published') {
+    fail('releaseState must be pre-release or published');
+  }
+  if (value.packageName !== 'scriptspect') fail('unexpected package name');
+  if (!/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u.test(value.packageVersion ?? '')) {
+    fail('package version must be stable semver');
+  }
+  if (!/^[0-9a-f]{40}$/u.test(value.sourceCommit ?? '')) {
+    fail('source commit must be an exact lowercase SHA');
+  }
+  if (!Number.isInteger(value.nodeMajor) || (value.nodeMajor ?? 0) < 22) {
+    fail('nodeMajor must be at least 22');
+  }
+  if (value.repository !== 'https://github.com/Tom409114/scriptspect') {
+    fail('unexpected repository');
+  }
+  if (value.releaseState === 'pre-release') {
+    if (value.releaseEvidence !== undefined) {
+      fail('pre-release state must not contain terminal release evidence');
+    }
+  } else {
+    if (value.packageVersion === '0.0.0') fail('published state needs a real package version');
+    if (value.releaseEvidence === undefined) {
+      fail('published state needs terminal release evidence');
+    }
+    const statusDirectory = dirname(resolve(path));
+    const evidenceDirectory = resolve(statusDirectory, 'validation', 'releases');
+    if (
+      value.releaseEvidence.receiptPath.trim() === '' ||
+      isAbsolute(value.releaseEvidence.receiptPath)
+    ) {
+      fail('terminal release evidence receiptPath must be a relative path');
+    }
+    const receiptPath = resolve(statusDirectory, value.releaseEvidence.receiptPath);
+    const receiptRelativeToEvidence = relative(evidenceDirectory, receiptPath);
+    if (
+      receiptRelativeToEvidence === '' ||
+      receiptRelativeToEvidence.startsWith('..') ||
+      isAbsolute(receiptRelativeToEvidence)
+    ) {
+      fail('terminal release evidence receiptPath escapes docs/validation/releases');
+    }
+    try {
+      const receipt = validateReadmeReleaseReceipt(JSON.parse(readFileSync(receiptPath, 'utf8')));
+      if (value.releaseEvidence.digest !== canonicalJsonDigest(receipt)) {
+        fail('terminal release evidence receipt digest does not match');
+      }
+      validateReceiptAgainstStatus(receipt, value);
+    } catch (error) {
+      fail(
+        `invalid terminal release evidence: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+  return value as ReadmeStatus;
+}
+
+function marker(name: string, edge: 'start' | 'end'): string {
+  return `<!-- readme-state:${name}:${edge} -->`;
+}
+
+function replaceBlock(markdown: string, name: string, body: string): string {
+  const start = marker(name, 'start');
+  const end = marker(name, 'end');
+  const startIndex = markdown.indexOf(start);
+  const endIndex = markdown.indexOf(end);
+  if (startIndex < 0 || endIndex < 0 || endIndex < startIndex) {
+    fail(`missing or invalid ${name} markers`);
+  }
+  if (markdown.indexOf(start, startIndex + start.length) >= 0)
+    fail(`duplicate ${name} start marker`);
+  if (markdown.indexOf(end, endIndex + end.length) >= 0) fail(`duplicate ${name} end marker`);
+  return `${markdown.slice(0, startIndex)}${start}\n${body.trim()}\n${end}${markdown.slice(
+    endIndex + end.length,
+  )}`;
+}
+
+function releaseUrls(status: ReadmeStatus): { npm: string; release: string; tag: string } {
+  const tag = `v${status.packageVersion}`;
+  return {
+    tag,
+    npm: `https://www.npmjs.com/package/${status.packageName}/v/${status.packageVersion}`,
+    release: `${status.repository}/releases/tag/${tag}`,
+  };
+}
+
+function overview(status: ReadmeStatus, locale: Locale): string {
+  if (status.releaseState === 'pre-release') {
+    return locale === 'english'
+      ? `> [!IMPORTANT]
+> This repository is a **pre-release source evaluation**. The npm package and
+> public Action tag do not exist yet; the copy-paste paths below deliberately
+> use an immutable source commit.
+
+**[See the real demo](#before-result-and-after)** · **[Evaluate from source](#evaluate-from-source-pre-release)** · **[GitHub Actions](#github-actions-preview-pre-release)** · **[Rules](docs/rules/README.md)**`
+      : `> [!IMPORTANT]
+> 本仓库目前是**预发布源码评估版**。npm package 与公开 Action tag 尚不存在；下面所有可复制步骤都特意固定到不可变 source commit。
+
+**[查看真实 demo](#修复前分析结果与修复后)** · **[从源码评估](#从源码评估evaluate-from-source-pre-release)** · **[GitHub Actions](#github-actions-预览pre-release)** · **[规则列表](docs/rules/README.md)**`;
+  }
+  const urls = releaseUrls(status);
+  return locale === 'english'
+    ? `> [!TIP]
+> Verified release: [\`${status.packageName}@${status.packageVersion}\`](${urls.npm}). The immutable Action
+> tag is [\`${urls.tag}\`](${urls.release}); security-sensitive workflows can pin
+> the full release commit \`${status.sourceCommit}\`.
+
+**[Run in 30 seconds](#quick-start)** · **[See the real demo](#before-result-and-after)** · **[GitHub Actions](#github-actions)** · **[Rules](docs/rules/README.md)**`
+    : `> [!TIP]
+> 已验证 release：[\`${status.packageName}@${status.packageVersion}\`](${urls.npm})。不可变 Action tag 是
+> [\`${urls.tag}\`](${urls.release})；安全敏感的 workflow 可以固定到完整 release commit
+> \`${status.sourceCommit}\`。
+
+**[30 秒开始](#快速开始quick-start)** · **[查看真实 demo](#修复前分析结果与修复后)** · **[GitHub Actions](#github-actions)** · **[规则列表](docs/rules/README.md)**`;
+}
+
+function evaluate(status: ReadmeStatus, locale: Locale): string {
+  if (status.releaseState === 'pre-release') {
+    return locale === 'english'
+      ? `<!-- readme-section: evaluate -->
+## Evaluate from source (pre-release)
+
+Requires Node.js ${status.nodeMajor} or newer and pnpm via Corepack. Clone the repository, check
+out the reviewed commit, install exactly from the lockfile, build, and scan the
+versioned demo fixture. Findings exit \`1\`; a clean scan exits \`0\`; invalid input,
+configuration, or I/O exits \`2\`.
+
+\`\`\`bash
+git clone ${status.repository}.git
+cd scriptspect
+git checkout ${status.sourceCommit}
+corepack enable
+pnpm install --frozen-lockfile
+pnpm build
+node dist/cli.mjs tests/fixtures/readme-demo
+\`\`\`
+
+There is deliberately no \`npx scriptspect\` quick start yet. The machine-readable
+release state is [docs/readme-status.json](docs/readme-status.json).`
+      : `<!-- readme-section: evaluate -->
+## 从源码评估（Evaluate from source (pre-release)）
+
+需要 Node.js ${status.nodeMajor} 或更高版本，并通过 Corepack 使用 pnpm。克隆仓库、检出经审阅的 commit、严格按 lockfile 安装、构建，再扫描版本化 demo fixture。存在 finding 时退出 \`1\`；clean scan 退出 \`0\`；无效输入、配置或 I/O 退出 \`2\`。
+
+\`\`\`bash
+git clone ${status.repository}.git
+cd scriptspect
+git checkout ${status.sourceCommit}
+corepack enable
+pnpm install --frozen-lockfile
+pnpm build
+node dist/cli.mjs tests/fixtures/readme-demo
+\`\`\`
+
+这里特意还没有 \`npx scriptspect\` 快速开始。机器可读的 release state 见 [docs/readme-status.json](docs/readme-status.json)。`;
+  }
+  const urls = releaseUrls(status);
+  return locale === 'english'
+    ? `<!-- readme-section: evaluate -->
+## Quick start
+
+Requires Node.js ${status.nodeMajor} or newer. Run the exact [verified npm release](${urls.npm})
+without a global install:
+
+\`\`\`bash
+npx --yes ${status.packageName}@${status.packageVersion} .
+\`\`\`
+
+With pnpm:
+
+\`\`\`bash
+pnpm dlx ${status.packageName}@${status.packageVersion} .
+\`\`\`
+
+Findings exit \`1\`; a clean scan exits \`0\`; invalid input, configuration, or I/O
+exits \`2\`. Start with \`--fix-dry-run\` before applying any reviewed fix.`
+    : `<!-- readme-section: evaluate -->
+## 快速开始（Quick start）
+
+需要 Node.js ${status.nodeMajor} 或更高版本。无需全局安装，直接运行准确的[已验证 npm release](${urls.npm})：
+
+\`\`\`bash
+npx --yes ${status.packageName}@${status.packageVersion} .
+\`\`\`
+
+使用 pnpm：
+
+\`\`\`bash
+pnpm dlx ${status.packageName}@${status.packageVersion} .
+\`\`\`
+
+存在 finding 时退出 \`1\`；clean scan 退出 \`0\`；无效输入、配置或 I/O 退出 \`2\`。应用任何经审查的修复前，请先使用 \`--fix-dry-run\`。`;
+}
+
+function action(status: ReadmeStatus, locale: Locale): string {
+  const checkout = 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1';
+  if (status.releaseState === 'pre-release') {
+    const workflow = `\`\`\`yaml
+name: scriptspect pre-release evaluation
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ${checkout} # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ${checkout} # v7.0.1
+        with:
+          repository: Tom409114/scriptspect
+          ref: ${status.sourceCommit}
+          path: .scriptspect
+          persist-credentials: false
+      - uses: ./.scriptspect
+        with:
+          path: .
+\`\`\``;
+    return locale === 'english'
+      ? `<!-- readme-section: action -->
+## GitHub Actions preview (pre-release)
+
+This complete example checks out both the consumer and an immutable ScriptSpect
+source commit, then runs the bundled local Action. Do not replace the commit
+with the nonexistent \`Tom409114/scriptspect@v0.1\` tag. After a verified release,
+security-sensitive workflows should continue pinning a full commit SHA.
+
+${workflow}
+
+The Action writes annotations, a job summary, and numeric outputs named
+\`exit-code\`, \`packages\`, \`scripts\`, \`errors\`, \`warnings\`, and \`advisories\` before
+marking a finding run as failed. Its default mode is read-only.`
+      : `<!-- readme-section: action -->
+## GitHub Actions 预览（pre-release）
+
+这个完整示例会同时检出 consumer 与不可变 ScriptSpect source commit，然后运行 bundled local Action。不要把 commit 替换为尚不存在的 \`Tom409114/scriptspect@v0.1\` tag。正式 release 得到验证后，安全敏感 workflow 仍应固定到完整 commit SHA。
+
+${workflow}
+
+Action 会先写入 annotations、job summary 以及名为 \`exit-code\`、\`packages\`、\`scripts\`、\`errors\`、\`warnings\`、\`advisories\` 的数字 outputs，再把 finding run 标记为失败。默认模式只读。`;
+  }
+  const urls = releaseUrls(status);
+  const workflow = `\`\`\`yaml
+name: scriptspect
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ${checkout} # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: Tom409114/scriptspect@${urls.tag}
+        with:
+          path: .
+\`\`\``;
+  return locale === 'english'
+    ? `<!-- readme-section: action -->
+## GitHub Actions
+
+Use the [verified immutable release tag](${urls.release}) for readable workflows.
+For the strongest supply-chain pin, replace \`${urls.tag}\` with the full release
+commit \`${status.sourceCommit}\`.
+
+${workflow}
+
+The Action writes annotations, a job summary, and numeric outputs named
+\`exit-code\`, \`packages\`, \`scripts\`, \`errors\`, \`warnings\`, and \`advisories\` before
+marking a finding run as failed. Its default mode is read-only.`
+    : `<!-- readme-section: action -->
+## GitHub Actions
+
+使用[已验证的不可变 release tag](${urls.release})可以保持 workflow 易读。若要获得最严格的供应链固定，请把 \`${urls.tag}\` 替换为完整 release commit \`${status.sourceCommit}\`。
+
+${workflow}
+
+Action 会先写入 annotations、job summary 以及名为 \`exit-code\`、\`packages\`、\`scripts\`、\`errors\`、\`warnings\`、\`advisories\` 的数字 outputs，再把 finding run 标记为失败。默认模式只读。`;
+}
+
+function releaseRow(status: ReadmeStatus, locale: Locale): string {
+  if (status.releaseState === 'pre-release') {
+    return locale === 'english'
+      ? '**Release:** pre-release; no npm package or public Action reference yet.'
+      : '**Release:** pre-release；目前没有 npm package 或公开 Action reference。';
+  }
+  const urls = releaseUrls(status);
+  return locale === 'english'
+    ? `**Release:** [npm ${status.packageVersion}](${urls.npm}) · [Action ${urls.tag}](${urls.release}) · full SHA \`${status.sourceCommit}\`.`
+    : `**Release:** [npm ${status.packageVersion}](${urls.npm}) · [Action ${urls.tag}](${urls.release}) · 完整 SHA \`${status.sourceCommit}\`。`;
+}
+
+function scopeTable(status: ReadmeStatus, locale: Locale): string {
+  const header =
+    locale === 'english'
+      ? status.releaseState === 'pre-release'
+        ? 'Current source-evaluation behavior'
+        : 'Current behavior'
+      : status.releaseState === 'pre-release'
+        ? '当前源码评估行为'
+        : '当前行为';
+  return locale === 'english'
+    ? `| Area | ${header} |
+| --- | --- |
+| Projects | root \`package.json\` plus npm/Yarn/Bun workspaces and \`pnpm-workspace.yaml\` |
+| Targets | \`posix-sh\` + \`cmd\` by default; opt-in \`powershell\` evidence |
+| Findings | error, warning, and advisory with high/medium confidence |
+| Output | stylish terminal text, versioned JSON, GitHub annotations + summary |
+| Fixes | dry-run plus provable safe/conditional rewrites; ambiguous cases stay manual |
+| Privacy | offline analysis; scripts are not executed; no telemetry |`
+    : `| 范围 | ${header} |
+| --- | --- |
+| Projects | 根 \`package.json\`，以及 npm/Yarn/Bun workspaces 与 \`pnpm-workspace.yaml\` |
+| Targets | 默认 \`posix-sh\` + \`cmd\`；可选 \`powershell\` evidence |
+| Findings | error、warning、advisory，并带 high/medium confidence |
+| Output | stylish terminal text、versioned JSON、GitHub annotations + summary |
+| Fixes | dry-run 以及可证明的 safe/conditional rewrites；ambiguous case 保持 manual |
+| Privacy | 离线分析；不执行 scripts；无 telemetry |`;
+}
+
+function productionFaq(status: ReadmeStatus, locale: Locale): string {
+  if (status.releaseState === 'pre-release') {
+    return locale === 'english'
+      ? `**Can I use it in production CI today?** Treat this source checkout as an
+evaluation build. Wait for public npm, Release, provenance, checksum, and
+immutable Action-consumer evidence before depending on a released reference.`
+      : '**现在能在 production CI 使用吗？** 请把这份 source checkout 当作 evaluation build。等待公开 npm、Release、provenance、checksum 与 immutable Action-consumer evidence 齐全后，再依赖 released reference。';
+  }
+  const urls = releaseUrls(status);
+  return locale === 'english'
+    ? `**Can I use it in production CI today?** Yes—use the verified \`${status.packageName}@${status.packageVersion}\`
+package or immutable \`${urls.tag}\` Action reference above. Pin \`${status.sourceCommit}\`
+when your policy requires an exact commit.`
+    : `**现在能在 production CI 使用吗？** 可以——请使用上方已验证的 \`${status.packageName}@${status.packageVersion}\` package 或不可变 \`${urls.tag}\` Action reference。若策略要求精确 commit，请固定到 \`${status.sourceCommit}\`。`;
+}
+
+function render(markdown: string, status: ReadmeStatus, locale: Locale): string {
+  let result = markdown;
+  result = replaceBlock(result, 'overview', overview(status, locale));
+  result = replaceBlock(result, 'evaluate', evaluate(status, locale));
+  result = replaceBlock(result, 'action', action(status, locale));
+  result = replaceBlock(result, 'scope-table', scopeTable(status, locale));
+  result = replaceBlock(result, 'release-row', releaseRow(status, locale));
+  result = replaceBlock(result, 'production-faq', productionFaq(status, locale));
+  return result;
+}
+
+const options = parseOptions(process.argv.slice(2));
+const status = parseStatus(options.status);
+const homepages = (
+  [
+    ['english', options.english],
+    ['chinese', options.chinese],
+  ] as const
+).map(([locale, path]) => {
+  const current = readFileSync(path, 'utf8');
+  const rendered = render(current, status, locale);
+  if (options.check) {
+    if (rendered !== current) fail(`${locale} homepage is stale for ${status.releaseState}`);
+  }
+  return { path, rendered };
+});
+if (!options.check) {
+  for (const homepage of homepages) writeFileSync(homepage.path, homepage.rendered);
+}
+
+console.log(`README state ${options.check ? 'verified' : 'rendered'} (${status.releaseState})`);

--- a/tools/verify-readme-release-evidence.ts
+++ b/tools/verify-readme-release-evidence.ts
@@ -1,0 +1,581 @@
+import { createHash } from 'node:crypto';
+import { readFile, realpath } from 'node:fs/promises';
+import { dirname, isAbsolute, relative, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import {
+  type ReadmeReleaseReceipt,
+  validateReadmeReleaseReceipt,
+  validateReceiptAgainstStatus,
+} from './readme-release-receipt.js';
+import {
+  type ConsumedState,
+  canonicalJsonDigest,
+  type FinalVerification,
+  validateReleaseState,
+  verifyFinalIdempotency,
+  verifyPublishedRelease,
+} from './release/release-state.mjs';
+
+const defaultRepositoryRoot = fileURLToPath(new URL('..', import.meta.url));
+const githubApiVersion = '2022-11-28';
+
+type JsonObject = Record<string, unknown>;
+
+type BaseReadmeStatus = {
+  schemaVersion: 1;
+  packageName: 'scriptspect';
+  packageVersion: string;
+  sourceCommit: string;
+  nodeMajor: number;
+  repository: 'https://github.com/Tom409114/scriptspect';
+};
+
+type PreReleaseReadmeStatus = BaseReadmeStatus & {
+  releaseState: 'pre-release';
+};
+
+type PublishedReadmeStatus = BaseReadmeStatus & {
+  releaseState: 'published';
+  releaseEvidence: { receiptPath: string; digest: string };
+};
+
+type ReadmeStatus = PreReleaseReadmeStatus | PublishedReadmeStatus;
+
+export type VerifyReadmeReleaseEvidenceOptions = {
+  repositoryRoot?: string;
+  statusPath?: string;
+  githubToken?: string;
+  fetchImpl?: typeof fetch;
+};
+
+export type VerifiedReadmeReleaseEvidence =
+  | {
+      releaseState: 'pre-release';
+      remoteVerification: 'not-required';
+      repository: BaseReadmeStatus['repository'];
+      packageName: BaseReadmeStatus['packageName'];
+      packageVersion: string;
+      sourceCommit: string;
+    }
+  | {
+      releaseState: 'published';
+      remoteVerification: 'verified';
+      repository: ReadmeReleaseReceipt['repository'];
+      packageName: string;
+      version: string;
+      tag: string;
+      commit: string;
+      releaseId: number;
+      intentCheckRunId: number;
+      publishRunId: number;
+      finalVerificationAssetId: number;
+      finalVerificationDigest: string;
+    };
+
+function objectValue(value: unknown, label: string): JsonObject {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as JsonObject;
+}
+
+function arrayValue(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  return value;
+}
+
+function stringValue(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function positiveInteger(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return value as number;
+}
+
+function sha256(value: unknown, label: string): string {
+  const digest = stringValue(value, label);
+  if (!/^[0-9a-f]{64}$/u.test(digest)) throw new Error(`${label} must be a SHA-256 digest`);
+  return digest;
+}
+
+function equal(actual: unknown, expected: unknown, label: string): void {
+  if (actual !== expected) throw new Error(`${label} does not match the terminal release state`);
+}
+
+function parseJson(text: string, label: string): unknown {
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new Error(`${label} is not valid JSON`);
+  }
+}
+
+async function readJson(path: string, label: string): Promise<unknown> {
+  let text: string;
+  try {
+    text = await readFile(path, 'utf8');
+  } catch {
+    throw new Error(`${label} could not be read`);
+  }
+  return parseJson(text, label);
+}
+
+function validateStatus(value: unknown): ReadmeStatus {
+  const status = objectValue(value, 'README status');
+  if (status.schemaVersion !== 1) throw new Error('README status schemaVersion is unsupported');
+  if (status.packageName !== 'scriptspect')
+    throw new Error('README status packageName is unexpected');
+  const packageVersion = stringValue(status.packageVersion, 'README status packageVersion');
+  if (!/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u.test(packageVersion)) {
+    throw new Error('README status packageVersion must be stable semver');
+  }
+  const sourceCommit = stringValue(status.sourceCommit, 'README status sourceCommit');
+  if (!/^[0-9a-f]{40}$/u.test(sourceCommit)) {
+    throw new Error('README status sourceCommit must be an exact lowercase SHA');
+  }
+  if (!Number.isInteger(status.nodeMajor) || (status.nodeMajor as number) < 22) {
+    throw new Error('README status nodeMajor must be at least 22');
+  }
+  if (status.repository !== 'https://github.com/Tom409114/scriptspect') {
+    throw new Error('README status repository is unexpected');
+  }
+  const base = {
+    schemaVersion: 1 as const,
+    packageName: 'scriptspect' as const,
+    packageVersion,
+    sourceCommit,
+    nodeMajor: status.nodeMajor as number,
+    repository: 'https://github.com/Tom409114/scriptspect' as const,
+  };
+  if (status.releaseState === 'pre-release') {
+    if (status.releaseEvidence !== undefined) {
+      throw new Error('pre-release README status must not contain releaseEvidence');
+    }
+    return { ...base, releaseState: 'pre-release' };
+  }
+  if (status.releaseState !== 'published') {
+    throw new Error('README status releaseState is unsupported');
+  }
+  if (packageVersion === '0.0.0') {
+    throw new Error('published README status needs a released packageVersion');
+  }
+  const releaseEvidence = objectValue(status.releaseEvidence, 'README status releaseEvidence');
+  const digest = sha256(releaseEvidence.digest, 'README status receipt digest');
+  const receiptPath = stringValue(releaseEvidence.receiptPath, 'README status receiptPath');
+  if (isAbsolute(receiptPath)) throw new Error('README status receiptPath must be relative');
+  return {
+    ...base,
+    releaseState: 'published',
+    releaseEvidence: { receiptPath, digest },
+  };
+}
+
+function isInside(parent: string, candidate: string): boolean {
+  const pathFromParent = relative(parent, candidate);
+  return pathFromParent !== '' && !pathFromParent.startsWith('..') && !isAbsolute(pathFromParent);
+}
+
+async function loadLocalEvidence(
+  repositoryRoot: string,
+  statusPath: string,
+): Promise<{
+  statusValue: unknown;
+  status: ReadmeStatus;
+  receipt?: ReadmeReleaseReceipt;
+}> {
+  const canonicalRoot = await realpath(repositoryRoot);
+  const canonicalStatusPath = await realpath(statusPath);
+  const statusValue = await readJson(canonicalStatusPath, 'README status');
+  const status = validateStatus(statusValue);
+  if (status.releaseState === 'pre-release') return { statusValue, status };
+  const allowedReceiptRoot = await realpath(
+    resolve(canonicalRoot, 'docs', 'validation', 'releases'),
+  );
+  const receiptCandidate = resolve(
+    dirname(canonicalStatusPath),
+    status.releaseEvidence.receiptPath,
+  );
+  const canonicalReceiptPath = await realpath(receiptCandidate);
+  if (!isInside(allowedReceiptRoot, canonicalReceiptPath)) {
+    throw new Error('README release receipt must stay under docs/validation/releases');
+  }
+  const receiptValue = await readJson(canonicalReceiptPath, 'README release receipt');
+  const receipt = validateReadmeReleaseReceipt(receiptValue);
+  equal(
+    canonicalJsonDigest(receipt),
+    status.releaseEvidence.digest,
+    'README status receipt digest',
+  );
+  validateReceiptAgainstStatus(receipt, statusValue);
+  equal(status.repository, receipt.repository, 'README status repository');
+  equal(status.packageName, 'scriptspect', 'README status packageName');
+  equal(status.packageVersion, receipt.finalVerification.version, 'README status packageVersion');
+  equal(status.sourceCommit, receipt.finalVerification.commit, 'README status sourceCommit');
+  return { statusValue, status, receipt };
+}
+
+function githubHeaders(githubToken: string | undefined, accept: string): Record<string, string> {
+  return {
+    accept,
+    ...(githubToken === undefined ? {} : { authorization: `Bearer ${githubToken}` }),
+    'user-agent': 'scriptspect-readme-release-evidence',
+    'x-github-api-version': githubApiVersion,
+  };
+}
+
+async function request(
+  fetchImpl: typeof fetch,
+  url: string,
+  label: string,
+  init?: RequestInit,
+): Promise<Response> {
+  let response: Response;
+  try {
+    response = await fetchImpl(url, init);
+  } catch (error) {
+    throw new Error(`${label} request failed: ${String(error)}`);
+  }
+  if (!response.ok) throw new Error(`${label} request failed with HTTP ${response.status}`);
+  return response;
+}
+
+async function requestJson(
+  fetchImpl: typeof fetch,
+  url: string,
+  label: string,
+  init?: RequestInit,
+): Promise<unknown> {
+  const response = await request(fetchImpl, url, label, init);
+  try {
+    return (await response.json()) as unknown;
+  } catch {
+    throw new Error(`${label} response is not valid JSON`);
+  }
+}
+
+function validateCheckRun(value: unknown, receipt: ReadmeReleaseReceipt): ConsumedState {
+  const check = objectValue(value, 'intent check run');
+  equal(
+    positiveInteger(check.id, 'intent check run id'),
+    receipt.intentCheckRunId,
+    'intent check run id',
+  );
+  equal(
+    stringValue(check.name, 'intent check run name'),
+    'release-intent',
+    'intent check run name',
+  );
+  equal(
+    stringValue(check.status, 'intent check run status'),
+    'completed',
+    'intent check run status',
+  );
+  equal(
+    stringValue(check.conclusion, 'intent check run conclusion'),
+    'success',
+    'intent check run conclusion',
+  );
+  const app = objectValue(check.app, 'intent check run app');
+  equal(
+    stringValue(app.slug, 'intent check run app slug'),
+    'github-actions',
+    'intent check run app slug',
+  );
+  const output = objectValue(check.output, 'intent check run output');
+  const state = validateReleaseState(
+    parseJson(
+      stringValue(output.text, 'intent check run output.text'),
+      'intent check run output.text',
+    ),
+  );
+  if (state.state !== 'consumed') throw new Error('intent check run state must be consumed');
+  equal(
+    stringValue(check.head_sha, 'intent check run head_sha'),
+    state.intent.mergeCommitSha,
+    'intent check run head_sha',
+  );
+  equal(
+    stringValue(check.external_id, 'intent check run external_id'),
+    state.intent.intentId,
+    'intent check run external_id',
+  );
+  return state;
+}
+
+function normalizedAliases(aliases: Array<{ name: string; target: string }>): string {
+  return JSON.stringify([...aliases].sort((left, right) => left.name.localeCompare(right.name)));
+}
+
+function bindReceiptToState(receipt: ReadmeReleaseReceipt, state: ConsumedState): void {
+  const final = receipt.finalVerification;
+  equal(final.intentId, state.intent.intentId, 'final verification intentId');
+  equal(final.version, state.intent.version, 'final verification version');
+  equal(final.tag, state.intent.tag, 'final verification tag');
+  equal(final.commit, state.intent.mergeCommitSha, 'final verification commit');
+  equal(final.releaseId, state.stagedDraft.releaseId, 'final verification releaseId');
+  equal(
+    final.candidateManifestDigest,
+    state.retainedCandidate.candidateManifestDigest,
+    'final verification candidateManifestDigest',
+  );
+  equal(
+    final.releaseManifestDigest,
+    state.stagedDraft.releaseManifestDigest,
+    'final verification releaseManifestDigest',
+  );
+  equal(
+    final.candidateNpmSRI,
+    state.retainedCandidate.npmSRI,
+    'final verification candidateNpmSRI',
+  );
+  equal(final.candidateNpmSRI, state.npmPublished.npmSRI, 'published npm SRI');
+  equal(final.version, state.npmPublished.publishedVersion, 'published npm version');
+  equal(
+    final.registryNpmSRI,
+    state.npmVerified.registryNpmSRI,
+    'final verification registryNpmSRI',
+  );
+  equal(
+    final.provenanceDigest,
+    state.npmVerified.provenanceDigest,
+    'final verification provenanceDigest',
+  );
+  equal(receipt.publishRunId, state.npmPublished.publishRunId, 'receipt publishRunId');
+  equal(
+    receipt.finalVerificationDigest,
+    state.finalPlanned.finalVerificationDigest,
+    'receipt finalVerificationDigest',
+  );
+  equal(
+    receipt.finalVerificationDigest,
+    state.consumed.finalVerificationDigest,
+    'consumed finalVerificationDigest',
+  );
+  equal(
+    receipt.finalVerificationAssetId,
+    state.consumed.finalVerificationAssetId,
+    'receipt finalVerificationAssetId',
+  );
+  equal(
+    normalizedAliases(final.aliases),
+    normalizedAliases(state.aliasesVerified.aliases.map(({ name, target }) => ({ name, target }))),
+    'final verification aliases',
+  );
+}
+
+function parseRepository(repository: string): { apiRoot: string } {
+  const url = new URL(repository);
+  const segments = url.pathname.split('/').filter(Boolean);
+  if (
+    url.protocol !== 'https:' ||
+    url.hostname !== 'github.com' ||
+    segments.length !== 2 ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error('README release receipt repository must be an exact GitHub repository URL');
+  }
+  return { apiRoot: `https://api.github.com/repos/${segments[0]}/${segments[1]}` };
+}
+
+function validateTagRef(value: unknown, tag: string, commit: string): void {
+  const tagRef = objectValue(value, `${tag} tag ref`);
+  const object = objectValue(tagRef.object, `${tag} tag ref object`);
+  equal(stringValue(tagRef.ref, `${tag} tag ref name`), `refs/tags/${tag}`, `${tag} tag ref name`);
+  equal(
+    stringValue(object.type, `${tag} tag ref object type`),
+    'commit',
+    `${tag} tag ref object type`,
+  );
+  equal(stringValue(object.sha, `${tag} tag ref target`), commit, `${tag} tag ref target`);
+}
+
+function releaseSnapshot(
+  value: unknown,
+  tagRefValue: unknown,
+): {
+  releaseId: number;
+  tag: string;
+  commit: string;
+  draft: boolean;
+  assets: Array<{ name: string; assetId: number; sha256: string }>;
+} {
+  const release = objectValue(value, 'GitHub Release');
+  const tag = stringValue(release.tag_name, 'GitHub Release tag_name');
+  const tagRef = objectValue(tagRefValue, `${tag} tag ref`);
+  const tagObject = objectValue(tagRef.object, `${tag} tag ref object`);
+  const assets = arrayValue(release.assets, 'GitHub Release assets').map((value, index) => {
+    const asset = objectValue(value, `GitHub Release assets[${index}]`);
+    const digest = stringValue(asset.digest, `GitHub Release assets[${index}].digest`);
+    if (!digest.startsWith('sha256:')) {
+      throw new Error(`GitHub Release assets[${index}].digest must use sha256`);
+    }
+    return {
+      name: stringValue(asset.name, `GitHub Release assets[${index}].name`),
+      assetId: positiveInteger(asset.id, `GitHub Release assets[${index}].id`),
+      sha256: sha256(digest.slice('sha256:'.length), `GitHub Release assets[${index}].digest`),
+    };
+  });
+  if (typeof release.draft !== 'boolean') throw new Error('GitHub Release draft must be boolean');
+  if (release.prerelease !== false) throw new Error('GitHub Release prerelease must be false');
+  return {
+    releaseId: positiveInteger(release.id, 'GitHub Release id'),
+    tag,
+    commit: stringValue(tagObject.sha, `${tag} tag ref target`),
+    draft: release.draft,
+    assets,
+  };
+}
+
+function validateNpmMetadata(value: unknown, packageName: string, final: FinalVerification): void {
+  const metadata = objectValue(value, 'npm exact-version metadata');
+  equal(stringValue(metadata.name, 'npm metadata name'), packageName, 'npm metadata name');
+  equal(
+    stringValue(metadata.version, 'npm metadata version'),
+    final.version,
+    'npm metadata version',
+  );
+  const dist = objectValue(metadata.dist, 'npm metadata dist');
+  equal(
+    stringValue(dist.integrity, 'npm metadata dist.integrity'),
+    final.registryNpmSRI,
+    'npm metadata dist.integrity',
+  );
+}
+
+export async function verifyReadmeReleaseEvidence(
+  options: VerifyReadmeReleaseEvidenceOptions = {},
+): Promise<VerifiedReadmeReleaseEvidence> {
+  const repositoryRoot = resolve(options.repositoryRoot ?? defaultRepositoryRoot);
+  const statusPath = resolve(repositoryRoot, options.statusPath ?? 'docs/readme-status.json');
+  const localEvidence = await loadLocalEvidence(repositoryRoot, statusPath);
+  if (localEvidence.status.releaseState === 'pre-release') {
+    return {
+      releaseState: 'pre-release',
+      remoteVerification: 'not-required',
+      repository: localEvidence.status.repository,
+      packageName: localEvidence.status.packageName,
+      packageVersion: localEvidence.status.packageVersion,
+      sourceCommit: localEvidence.status.sourceCommit,
+    };
+  }
+  const { status, receipt } = localEvidence;
+  if (receipt === undefined) throw new Error('published README status is missing its receipt');
+  const githubToken = options.githubToken ?? process.env.GITHUB_TOKEN;
+  if (githubToken === undefined || githubToken.trim() === '') {
+    throw new Error('published README evidence verification requires GITHUB_TOKEN');
+  }
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  if (typeof fetchImpl !== 'function') throw new Error('fetch is unavailable');
+  const { apiRoot } = parseRepository(receipt.repository);
+  const githubJsonInit: RequestInit = {
+    headers: githubHeaders(githubToken, 'application/vnd.github+json'),
+  };
+
+  const checkRunValue = await requestJson(
+    fetchImpl,
+    `${apiRoot}/check-runs/${receipt.intentCheckRunId}`,
+    'intent check run',
+    githubJsonInit,
+  );
+  const state = validateCheckRun(checkRunValue, receipt);
+  bindReceiptToState(receipt, state);
+
+  const exactTagUrl = `${apiRoot}/git/ref/tags/${encodeURIComponent(receipt.finalVerification.tag)}`;
+  const [releaseValue, exactTagValue] = await Promise.all([
+    requestJson(
+      fetchImpl,
+      `${apiRoot}/releases/tags/${encodeURIComponent(receipt.finalVerification.tag)}`,
+      'GitHub Release',
+      githubJsonInit,
+    ),
+    requestJson(fetchImpl, exactTagUrl, 'exact tag ref', githubJsonInit),
+  ]);
+  validateTagRef(exactTagValue, receipt.finalVerification.tag, receipt.finalVerification.commit);
+  const observedRelease = releaseSnapshot(releaseValue, exactTagValue);
+  verifyPublishedRelease({ state, observed: observedRelease });
+
+  const assetInit: RequestInit = {
+    headers: githubHeaders(githubToken, 'application/octet-stream'),
+    redirect: 'follow',
+  };
+  const finalAssetResponse = await request(
+    fetchImpl,
+    `${apiRoot}/releases/assets/${receipt.finalVerificationAssetId}`,
+    'final verification asset',
+    assetInit,
+  );
+  const finalAssetBytes = Buffer.from(await finalAssetResponse.arrayBuffer());
+  equal(
+    createHash('sha256').update(finalAssetBytes).digest('hex'),
+    receipt.finalVerificationDigest,
+    'downloaded final verification SHA-256',
+  );
+  const downloadedFinal = parseJson(
+    finalAssetBytes.toString('utf8'),
+    'downloaded final verification',
+  );
+  verifyFinalIdempotency(receipt.finalVerification, downloadedFinal);
+
+  const registryUrl = `https://registry.npmjs.org/${encodeURIComponent(status.packageName)}/${encodeURIComponent(receipt.finalVerification.version)}`;
+  const aliasRequests = receipt.finalVerification.aliases.map(async ({ name, target }) => {
+    const refValue = await requestJson(
+      fetchImpl,
+      `${apiRoot}/git/ref/tags/${encodeURIComponent(name)}`,
+      `${name} alias ref`,
+      githubJsonInit,
+    );
+    validateTagRef(refValue, name, target);
+  });
+  const [npmMetadata] = await Promise.all([
+    requestJson(fetchImpl, registryUrl, 'npm exact-version metadata', {
+      headers: { accept: 'application/json' },
+    }),
+    ...aliasRequests,
+  ]);
+  validateNpmMetadata(npmMetadata, status.packageName, receipt.finalVerification);
+
+  return {
+    releaseState: 'published',
+    remoteVerification: 'verified',
+    repository: receipt.repository,
+    packageName: status.packageName,
+    version: receipt.finalVerification.version,
+    tag: receipt.finalVerification.tag,
+    commit: receipt.finalVerification.commit,
+    releaseId: receipt.finalVerification.releaseId,
+    intentCheckRunId: receipt.intentCheckRunId,
+    publishRunId: receipt.publishRunId,
+    finalVerificationAssetId: receipt.finalVerificationAssetId,
+    finalVerificationDigest: receipt.finalVerificationDigest,
+  };
+}
+
+function parseCliStatusPath(arguments_: string[]): string | undefined {
+  if (arguments_.length === 0) return undefined;
+  if (arguments_.length === 2 && arguments_[0] === '--status' && arguments_[1]) {
+    return arguments_[1];
+  }
+  throw new Error('usage: verify-readme-release-evidence.ts [--status path]');
+}
+
+function isMain(): boolean {
+  if (process.argv[1] === undefined) return false;
+  return pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+}
+
+if (isMain()) {
+  verifyReadmeReleaseEvidence({ statusPath: parseCliStatusPath(process.argv.slice(2)) })
+    .then((result) => process.stdout.write(`${JSON.stringify(result)}\n`))
+    .catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`${JSON.stringify({ error: message })}\n`);
+      process.exitCode = 1;
+    });
+}


### PR DESCRIPTION
## Summary
- upgrade the GitHub homepage into a polished English/Chinese product page with real CLI and Action evidence
- make pre-release versus published install guidance explicit and fail closed
- ship package-only bilingual npm READMEs and deterministic release handoff evidence
- harden npm bootstrap, publication, checksums, aliases, and JSON Schema delivery

## Verification
- 64 test files: 1012 passed, 7 skipped
- TypeScript typecheck passed
- 18 changed TS/MJS files passed Biome
- workflow YAML and actionlint passed
- README parity, remote evidence, Markdown rendering, and package staging checks passed

## Release scope
This PR does not publish npm, create a tag, or merge the release PR. Those remain explicit maintainer actions after npm setup.