### PR TITLE
fix: fully encode scoped package purls

### DIFF
--- a/tools/release/verify-provenance.mjs
+++ b/tools/release/verify-provenance.mjs
@@ -92,7 +92,7 @@ function packageReference(entry, expected) {
 }
 
 function packagePurl(name, version) {
-  const encodedName = name.startsWith('@') ? name.replace('/', '%2F') : name;
+  const encodedName = name.startsWith('@') ? name.replaceAll('/', '%2F') : name;
   return `pkg:npm/${encodedName}@${version}`;
 }
 


### PR DESCRIPTION
## Summary
- close the existing high-severity CodeQL incomplete-sanitization alert on default branch
- encode every slash when constructing a scoped npm package PURL

## Evidence
- CodeQL alert: https://github.com/Tom409114/scriptspect/security/code-scanning/1
- release-tools tests: 42 passed
- TypeScript typecheck passed
- Biome passed for the changed file