### PR TITLE
docs: make the homepage explain ScriptSpect at a glance

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-6f7bf7.svg"></a>
 </p>
 
-<p align="center"><strong>One script. Multiple shell interpretations. A finding tied to the target that breaks.</strong></p>
+<p align="center"><strong>Make package.json scripts work on macOS, Linux, and Windows—before CI or users find the breakage.</strong></p>
 
-ScriptSpect statically checks npm-style `package.json` scripts without running
-them. It identifies constructs that mean different things to `posix-sh`,
-Windows `cmd`, or optional `powershell`, points to the relevant span, and keeps
-automatic fixes behind explicit safety gates.
+ScriptSpect is a preflight checker for npm-style `package.json` scripts. Point
+it at a Node.js project or monorepo: without running the scripts, it shows the
+exact command fragment that will break in `posix-sh`, Windows `cmd`, or optional
+`powershell`, explains the affected platform, and offers a fix only when its
+safety conditions are proved.
 
 <!-- readme-state:overview:start -->
 > [!IMPORTANT]
@@ -27,6 +28,29 @@ automatic fixes behind explicit safety gates.
 
 **[See the real demo](#before-result-and-after)** · **[Evaluate from source](#evaluate-from-source-pre-release)** · **[GitHub Actions](#github-actions-preview-pre-release)** · **[Rules](docs/rules/README.md)**
 <!-- readme-state:overview:end -->
+
+<!-- readme-section: purpose -->
+## What it does, who it is for, and how it works
+
+Use ScriptSpect if you maintain a JS/TS app, library, CLI, or monorepo; own CI
+or releases; or support contributors on more than one operating system. It
+solves the familiar failure where a script works on its author's Mac or Linux
+machine but fails for Windows users—or contains Windows-only syntax that fails
+on Unix CI.
+
+| Question | Direct answer |
+| --- | --- |
+| **Who uses it?** | JS/TS maintainers, monorepo owners, Windows contributors, and CI/release teams. |
+| **What problem does it catch?** | Shell-specific environment assignment, commands such as `rm`/`cp`/`mv`, expansion, redirection, operators, paths, explicit shell dependencies, and undeclared executables. |
+| **How does it check?** | It discovers the root package and workspaces, structurally parses every script for the selected shell targets, and never executes the target commands. |
+| **What do you get?** | An exact rule ID, package and script name, source span, affected shell/OS, severity, confidence, explanation, and terminal/JSON/PR-annotation output. |
+| **How does it help fix it?** | `--fix-dry-run` previews a patch. `--fix` applies only proven safe or precondition-satisfied changes; ambiguous cases stay manual. |
+
+The mental model is: **repository → static target-shell analysis → exact
+findings → reviewable fix plan**. For the current pre-release, follow
+[Evaluate from source](#evaluate-from-source-pre-release), run
+`node dist/cli.mjs <your-project>`, and add `--fix-dry-run` to preview changes.
+For pull requests, copy the [GitHub Actions preview](#github-actions-preview-pre-release).
 
 <!-- readme-section: why -->
 ## Why it is useful
@@ -39,6 +63,10 @@ ScriptSpect uses a target-specific structural parser rather than scanning quoted
 text with a stack of regular expressions. It is intentionally not a full shell
 interpreter: findings should still be reviewed in the project that owns the
 script.
+
+[`scripts-doctor`](docs/comparison.md) is the adjacent analyzer baseline.
+`cross-env`, `shx`, and `rimraf` are remedies ScriptSpect may recommend when
+their preconditions are satisfied, not competing analyzers.
 
 <!-- readme-section: demo -->
 ## Before, result, and after
@@ -97,7 +125,7 @@ configuration, or I/O exits `2`.
 ```bash
 git clone https://github.com/Tom409114/scriptspect.git
 cd scriptspect
-git checkout bf37b4132508c685a91cc16a9c0a3058c252502e
+git checkout c9c671c8e150705d78d9169d4c5a8f22cb37fad0
 corepack enable
 pnpm install --frozen-lockfile
 pnpm build
@@ -151,7 +179,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Tom409114/scriptspect
-          ref: bf37b4132508c685a91cc16a9c0a3058c252502e
+          ref: c9c671c8e150705d78d9169d4c5a8f22cb37fad0
           path: .scriptspect
           persist-credentials: false
       - uses: ./.scriptspect
@@ -164,15 +192,15 @@ The Action writes annotations, a job summary, and numeric outputs named
 marking a finding run as failed. Its default mode is read-only.
 <!-- readme-state:action:end -->
 
-**Real hosted proof — not a mock screenshot.** On `main` at `bf37b413`, public
-[CI run #33467290054](https://github.com/Tom409114/scriptspect/actions/runs/33467290054)
+**Real hosted proof — not a mock screenshot.** On `main` at `c9c671c8`, public
+[CI run #33482453059](https://github.com/Tom409114/scriptspect/actions/runs/33482453059)
 consumed `uses: ./` against both clean and broken fixtures. The clean consumer
 reported `1 package · 1 script · 0 errors`; the broken fixture emitted 2 check
 annotations, including `PS010: scripts.clean` on `package.json`.
 
 ![Generated card summarizing the verified hosted Action run](docs/assets/demo/action.svg)
 
-[Selectable Action evidence](docs/assets/demo/action.txt) · [Committed source evidence](docs/validation/readme-action-evidence.json) · [Open the hosted job](https://github.com/Tom409114/scriptspect/actions/runs/33467290054/job/99729679961)
+[Selectable Action evidence](docs/assets/demo/action.txt) · [Committed source evidence](docs/validation/readme-action-evidence.json) · [Open the hosted job](https://github.com/Tom409114/scriptspect/actions/runs/33482453059/job/99774890433)
 
 <!-- readme-section: config -->
 ## Minimal configuration

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,9 +12,12 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-6f7bf7.svg"></a>
 </p>
 
-<p align="center"><strong>同一条脚本，多种 shell 解释；每条 finding 都明确指出真正会出错的 target。</strong></p>
+<p align="center"><strong>在 CI 或用户踩坑之前，先让 package.json scripts 在 macOS、Linux 与 Windows 上真正可用。</strong></p>
 
-ScriptSpect 会静态检查 npm 风格的 `package.json` scripts，并且不会运行它们。它识别在 `posix-sh`、Windows `cmd` 或可选 `powershell` 下含义不同的结构，精确指向相关 span，并只在安全条件得到证明后提供自动修复。
+ScriptSpect 是 npm 风格 `package.json` scripts 的跨平台预检工具。把一个
+Node.js 项目或 monorepo 交给它，它不会执行 scripts，而是直接指出哪一段
+命令会在 `posix-sh`、Windows `cmd` 或可选 `powershell` 下出错、影响哪个
+平台、为什么出错，并且只在安全条件得到证明时提供修复。
 
 <!-- readme-state:overview:start -->
 > [!IMPORTANT]
@@ -22,6 +25,27 @@ ScriptSpect 会静态检查 npm 风格的 `package.json` scripts，并且不会�
 
 **[查看真实 demo](#修复前分析结果与修复后)** · **[从源码评估](#从源码评估evaluate-from-source-pre-release)** · **[GitHub Actions](#github-actions-预览pre-release)** · **[规则列表](docs/rules/README.md)**
 <!-- readme-state:overview:end -->
+
+<!-- readme-section: purpose -->
+## 它到底做什么、谁适合用、怎么工作
+
+如果你维护 JS/TS 应用、库、CLI 或 monorepo，负责 CI/release，或者需要
+同时支持不同操作系统的贡献者，就适合使用 ScriptSpect。它解决的是最常见
+的那类故障：脚本在作者的 Mac/Linux 上正常，到了 Windows 用户或 Windows
+CI 就失败；反过来，Windows-only 写法也可能在 Unix CI 中出错。
+
+| 问题 | 直接答案 |
+| --- | --- |
+| **谁来用？** | JS/TS 维护者、monorepo 负责人、Windows 贡献者，以及 CI/release 团队。 |
+| **解决什么问题？** | 找出 shell-specific 的环境变量写法、`rm`/`cp`/`mv` 等命令、expansion、redirection、operator、path、显式 shell 依赖与未声明 executable。 |
+| **怎么检查？** | 自动发现根 package 与 workspaces，按所选 target shell 对每条 script 做结构化静态分析，绝不执行目标命令。 |
+| **最后得到什么？** | 精确 rule ID、package/script 名、source span、受影响 shell/OS、severity、confidence、解释，以及终端/JSON/PR annotation。 |
+| **怎么帮助修复？** | `--fix-dry-run` 先展示 patch；`--fix` 只应用已证明安全或满足前置条件的修改，模糊情况保持 manual。 |
+
+它的工作路径很简单：**repository → target-shell 静态分析 → 精确 findings →
+可审查的修复计划**。当前预发布版请先按[从源码评估](#从源码评估evaluate-from-source-pre-release)
+完成准备，再运行 `node dist/cli.mjs <your-project>`；加上 `--fix-dry-run`
+可以先看修改。PR 中使用时，复制 [GitHub Actions 预览](#github-actions-预览pre-release)。
 
 <!-- readme-section: why -->
 ## 为什么值得使用
@@ -31,6 +55,10 @@ ScriptSpect 会静态检查 npm 风格的 `package.json` scripts，并且不会�
 | 在另一种操作系统真正执行前，找出依赖特定 shell 的命令、operator、expansion、redirection、path 与未声明 executable。 | 每条 finding 都带有稳定 rule ID、package/script path、source span、severity、confidence 与受影响 targets。 | `safe`、`conditional`、`manual` 三类安全级别，避免在无法证明等价时进行“热心”改写。 |
 
 ScriptSpect 使用 target-specific 的结构化 parser，而不是用一组正则表达式扫描 quoted text。它有意不做完整 shell interpreter；finding 仍应由拥有该 script 的项目审查。
+
+[`scripts-doctor`](docs/comparison.md) 是相邻的 analyzer 基线。`cross-env`、
+`shx` 与 `rimraf` 是 ScriptSpect 在满足前置条件时可能推荐的修复手段，
+不是静态分析竞品。
 
 <!-- readme-section: demo -->
 ## 修复前、分析结果与修复后
@@ -81,7 +109,7 @@ ScriptSpect 使用 target-specific 的结构化 parser，而不是用一组正�
 ```bash
 git clone https://github.com/Tom409114/scriptspect.git
 cd scriptspect
-git checkout bf37b4132508c685a91cc16a9c0a3058c252502e
+git checkout c9c671c8e150705d78d9169d4c5a8f22cb37fad0
 corepack enable
 pnpm install --frozen-lockfile
 pnpm build
@@ -129,7 +157,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Tom409114/scriptspect
-          ref: bf37b4132508c685a91cc16a9c0a3058c252502e
+          ref: c9c671c8e150705d78d9169d4c5a8f22cb37fad0
           path: .scriptspect
           persist-credentials: false
       - uses: ./.scriptspect
@@ -140,11 +168,11 @@ jobs:
 Action 会先写入 annotations、job summary 以及名为 `exit-code`、`packages`、`scripts`、`errors`、`warnings`、`advisories` 的数字 outputs，再把 finding run 标记为失败。默认模式只读。
 <!-- readme-state:action:end -->
 
-**真实托管证据——不是模拟截图。** 在 `main` 的 `bf37b413` 上，公开的 [CI run #33467290054](https://github.com/Tom409114/scriptspect/actions/runs/33467290054) 使用 `uses: ./` 分别消费 clean 与 broken fixture。clean consumer 返回 `1 package · 1 script · 0 errors`；broken fixture 产生 2 条 check annotations，其中包括落在 `package.json` 上的 `PS010: scripts.clean`。
+**真实托管证据——不是模拟截图。** 在 `main` 的 `c9c671c8` 上，公开的 [CI run #33482453059](https://github.com/Tom409114/scriptspect/actions/runs/33482453059) 使用 `uses: ./` 分别消费 clean 与 broken fixture。clean consumer 返回 `1 package · 1 script · 0 errors`；broken fixture 产生 2 条 check annotations，其中包括落在 `package.json` 上的 `PS010: scripts.clean`。
 
 ![根据真实托管 Action run 生成的验证卡片](docs/assets/demo/action.svg)
 
-[可选择的 Action 证据文本](docs/assets/demo/action.txt) · [提交进仓库的源证据](docs/validation/readme-action-evidence.json) · [打开托管 job](https://github.com/Tom409114/scriptspect/actions/runs/33467290054/job/99729679961)
+[可选择的 Action 证据文本](docs/assets/demo/action.txt) · [提交进仓库的源证据](docs/validation/readme-action-evidence.json) · [打开托管 job](https://github.com/Tom409114/scriptspect/actions/runs/33482453059/job/99774890433)
 
 <!-- readme-section: config -->
 ## 最小配置

--- a/docs/assets/demo/action.svg
+++ b/docs/assets/demo/action.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="480" viewBox="0 0 1100 480" role="img" aria-labelledby="title desc" data-run-id="33467290054">
+<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="480" viewBox="0 0 1100 480" role="img" aria-labelledby="title desc" data-run-id="33482453059">
   <title id="title">Hosted Action evidence</title>
-  <desc id="desc">Public CI run 33467290054 passed at source commit bf37b413. A clean consumer returned zero errors, while the broken fixture produced 2 annotations including PS010: scripts.clean.</desc>
+  <desc id="desc">Public CI run 33482453059 passed at source commit c9c671c8. A clean consumer returned zero errors, while the broken fixture produced 2 annotations including PS010: scripts.clean.</desc>
   <defs>
     <linearGradient id="action-bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#090d1a"/>
@@ -25,7 +25,7 @@
   <rect x="1" y="1" width="1098" height="478" rx="21" fill="none" stroke="#7c8db5" stroke-opacity="0.28"/>
   <rect x="52" y="46" width="9" height="42" rx="4.5" fill="url(#action-line)"/>
   <text x="82" y="70" class="sans" fill="#f8fbff" font-size="30" font-weight="770">Hosted Action evidence</text>
-  <text x="82" y="94" class="mono muted" font-size="14">main @ bf37b413 · CI run #33467290054</text>
+  <text x="82" y="94" class="mono muted" font-size="14">main @ c9c671c8 · CI run #33482453059</text>
   <rect x="866" y="50" width="182" height="38" rx="19" fill="#10372f" stroke="#34d399" stroke-opacity="0.65"/>
   <circle cx="890" cy="69" r="7" fill="#34d399"/>
   <text x="908" y="75" class="sans" fill="#a7f3d0" font-size="16" font-weight="720">VERIFIED · PASS</text>

--- a/docs/assets/demo/action.txt
+++ b/docs/assets/demo/action.txt
@@ -1,7 +1,7 @@
 ScriptSpect hosted Action evidence
-workflow run: 33467290054 (success)
-workflow URL: https://github.com/Tom409114/scriptspect/actions/runs/33467290054
-source commit: bf37b4132508c685a91cc16a9c0a3058c252502e
+workflow run: 33482453059 (success)
+workflow URL: https://github.com/Tom409114/scriptspect/actions/runs/33482453059
+source commit: c9c671c8e150705d78d9169d4c5a8f22cb37fad0
 clean consumer: exit 0 · 1 package · 1 script · 0 errors
 broken fixture: 2 annotations
 - Action failure contract — .github: scriptspect action failed

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -31,7 +31,7 @@ are pinned in [`comparison/toolchain.json`](../comparison/toolchain.json).
 | Target shell matrix | every finding lists affected shells (posix-sh / cmd / powershell); default matrix = npm defaults (sh + cmd) |
 | Confidence + severity | every rule has confidence (high/medium) and severity (error/warn/advisory); any configured `error` is in the failure universe, and the warning budget is evaluated before display filtering |
 | Rule provenance | each rule documents shell-behavior evidence and real failure classes with good/bad examples |
-| Monorepo first-class | npm/pnpm/Yarn/Bun workspace discovery and per-package reporting; the controlled hosted 100-package/2-second benchmark passed in [run `33476006926`](https://github.com/Tom409114/scriptspect/actions/runs/33476006926) at exact `main` commit `50d02d44abdbfb3489516f39f4251481dfec1548`, but it is implementation evidence rather than an external-corpus performance or adoption claim |
+| Monorepo first-class | npm/pnpm/Yarn/Bun workspace discovery and per-package reporting; the controlled hosted 100-package/2-second benchmark passed in [run `33482453059`](https://github.com/Tom409114/scriptspect/actions/runs/33482453059) at exact `main` commit `c9c671c8e150705d78d9169d4c5a8f22cb37fad0`, but it is implementation evidence rather than an external-corpus performance or adoption claim |
 | Safe fix engine | safe / conditional / manual; `--fix` applies only replacements whose structural and dependency preconditions are proved; idempotency and formatting are regression-tested |
 | No execution | static only — safe to run on untrusted PRs |
 | GitHub-native | first-class Action, PR annotations, job summary; SARIF planned |

--- a/docs/readme-status.json
+++ b/docs/readme-status.json
@@ -3,7 +3,7 @@
   "releaseState": "pre-release",
   "packageName": "scriptspect",
   "packageVersion": "0.0.0",
-  "sourceCommit": "bf37b4132508c685a91cc16a9c0a3058c252502e",
+  "sourceCommit": "c9c671c8e150705d78d9169d4c5a8f22cb37fad0",
   "nodeMajor": 22,
   "repository": "https://github.com/Tom409114/scriptspect"
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,13 +4,15 @@ The links below record when each implementation slice first landed. A merged
 slice is not the same as satisfying its exit condition: release, hosted-CI,
 corpus, and adoption gates stay open until their public evidence exists.
 
-The latest hosted `main` snapshot is the merged [homepage/release hardening
-PR #78](https://github.com/Tom409114/scriptspect/pull/78) plus [CodeQL follow-up
-PR #79](https://github.com/Tom409114/scriptspect/pull/79). Its exact `main`
-commit passed [CI run `33476006926`](https://github.com/Tom409114/scriptspect/actions/runs/33476006926).
+The latest hosted `main` snapshot includes the merged [homepage/release hardening
+PR #78](https://github.com/Tom409114/scriptspect/pull/78), [CodeQL follow-up
+PR #79](https://github.com/Tom409114/scriptspect/pull/79), and [final spec-audit
+PR #80](https://github.com/Tom409114/scriptspect/pull/80). Exact `main` commit
+`c9c671c8e150705d78d9169d4c5a8f22cb37fad0` passed [CI run
+`33482453059`](https://github.com/Tom409114/scriptspect/actions/runs/33482453059).
 The still-open [v0.1.0 release PR #66](https://github.com/Tom409114/scriptspect/pull/66)
 has since advanced; its latest bot-authored run is
-[`action_required`](https://github.com/Tom409114/scriptspect/actions/runs/33476042317)
+[`action_required`](https://github.com/Tom409114/scriptspect/actions/runs/33482502821)
 under the documented manual-approval policy, so an older green PR-head run is
 not presented as current release evidence. The [DoD
 ledger](validation/v0.1-dod-2026-09-01.md) records the remaining approval,

--- a/docs/validation/readme-action-evidence.json
+++ b/docs/validation/readme-action-evidence.json
@@ -1,17 +1,17 @@
 {
   "schemaVersion": 1,
-  "capturedAt": "2026-09-01T03:46:10Z",
-  "sourceCommit": "bf37b4132508c685a91cc16a9c0a3058c252502e",
+  "capturedAt": "2026-09-01T07:33:33Z",
+  "sourceCommit": "c9c671c8e150705d78d9169d4c5a8f22cb37fad0",
   "workflowRun": {
-    "id": 33467290054,
+    "id": 33482453059,
     "name": "CI",
-    "url": "https://github.com/Tom409114/scriptspect/actions/runs/33467290054",
+    "url": "https://github.com/Tom409114/scriptspect/actions/runs/33482453059",
     "conclusion": "success"
   },
   "checkRun": {
-    "id": 99729679961,
+    "id": 99774890433,
     "name": "Bundled Action consumer",
-    "url": "https://github.com/Tom409114/scriptspect/actions/runs/33467290054/job/99729679961",
+    "url": "https://github.com/Tom409114/scriptspect/actions/runs/33482453059/job/99774890433",
     "annotationCount": 2,
     "summarySha256": "6f404488da1babb4ba885e873c5187e4e1c5179a2c868bc5324a2e3b8c71c404"
   },

--- a/docs/validation/spec-compliance-2026-09-01.md
+++ b/docs/validation/spec-compliance-2026-09-01.md
@@ -483,3 +483,17 @@
 | 组合回归 | `LOCAL PASS / HOSTED PENDING` | 稳定共享树上 69 个 test files：`1,074 passed / 8 skipped`；90% parser/rule coverage floor、typecheck、改动文件 Biome、Actionlint、README parity、生成物与 diff check 均通过。PR 与准确 merge-SHA 的 GitHub-hosted checks 仍需随后产生。 |
 
 该候选关闭了本轮新发现的仓库可修高/中项，但在其 PR 和准确 `main` SHA 的 hosted checks 成功前，不得把 `LOCAL PASS` 提升为 `HOSTED PASS`。M8 的 ≥100 人工裁决、shared-corpus adjudication、真实外部兴趣/onboarding/downstream 与时间型 KPI 继续保持 `EXTERNAL + TIME OPEN`。
+
+## PR #80 终审闭环（2026-09-01，追加）
+
+本节只更新上一节明确标为 `HOSTED PENDING` 的候选状态，不把绿色 CI 扩写成发布或外部采用证据。
+
+| 项目 | 最终状态 | 准确远程证据与仍开放边界 |
+|---|---|---|
+| workspace 与 Action root 边界 | `HOSTED PASS` | [PR #80](https://github.com/Tom409114/scriptspect/pull/80) 合并静态 glob base、动态 match 与 Action 向上 root search 的 fail-closed containment；PR required checks 全绿，merge commit `c9c671c8e150705d78d9169d4c5a8f22cb37fad0` 的 [main CI run `33482453059`](https://github.com/Tom409114/scriptspect/actions/runs/33482453059) 在 Windows/macOS/Linux × Node 22/24 上 success。 |
+| 1–1,000 corpus source contract | `HOSTED PASS / 1,000-REPO RUN OPEN` | collector/resolver/scanner 的分页、v2 evidence、v1 replay、数值边界与 rate-limit header fail-closed 回归已随上述准确 main run 通过；这只证明能力，不冒充一次已经完成的 1,000-repository 托管扫描。 |
+| 月度 evidence draft | `HOSTED CONTRACT PASS / REVIEWED DRAFT OPEN` | 只读、artifact-only workflow、missing/partial/null 语义、partial-run failure、双输出独占写入与 rollback 测试已随准确 main run 通过；首次真实 scheduled artifact 与人工 reviewer approval 仍未发生。 |
+| 组合回归 | `LOCAL + HOSTED PASS` | 合并前完整本地结果为 `69 test files / 1,074 passed / 8 skipped`，parser/rule 四项 coverage floor 均超过 90%；PR #80 checks 与准确 merge-SHA push CI 均 success。 |
+| README 可复制证据 | `REFRESHED` | 首页源码评估与本地 Action pin 更新到 exact source commit `c9c671c8e150705d78d9169d4c5a8f22cb37fad0`；真实 `uses: ./` clean/broken consumer、2 条 annotations 与 job summary 来自 main run `33482453059` 的 `Bundled Action consumer` job。 |
+
+[PR #66](https://github.com/Tom409114/scriptspect/pull/66) 仍为 OPEN/BLOCKED；PR #80 合并后 release-please 将其推进到 head `bdc8e1990096db8ca096a8462e3307322d7c9f65`，对应 run [`33482502821`](https://github.com/Tom409114/scriptspect/actions/runs/33482502821) 仍为 `action_required`。npm 404、0 tags、0 releases、Trusted Publishing、tag creation/floating alias policy 与 M8 外部/时间证据均未被本次工程闭环改变。因此总体仍是 **NOT RELEASE READY**。

--- a/docs/validation/v0.1-dod-2026-09-01.md
+++ b/docs/validation/v0.1-dod-2026-09-01.md
@@ -1,10 +1,10 @@
 # ScriptSpect v0.1 Definition of Done 核签账本
 
 - 日期：2026-09-01
-- 最后实现快照（本账本核验时）：`main` at `50d02d44abdbfb3489516f39f4251481dfec1548`
-- 已合并实现链：从 [PR #65](https://github.com/Tom409114/scriptspect/pull/65) 的 hardening，到 [#78](https://github.com/Tom409114/scriptspect/pull/78) 的首页/发布证据升级与 [#79](https://github.com/Tom409114/scriptspect/pull/79) 的 CodeQL 修复
-- 本次核验时保持开放的 release-please 候选：[PR #66](https://github.com/Tom409114/scriptspect/pull/66) at `390d7ccd61c79bedee182557bf4b6dc2bfbc7376`
-- README/status 固定的已审阅 runtime/Action evidence source：`bf37b4132508c685a91cc16a9c0a3058c252502e`
+- 最后实现快照（本账本核验时）：`main` at `c9c671c8e150705d78d9169d4c5a8f22cb37fad0`
+- 已合并实现链：从 [PR #65](https://github.com/Tom409114/scriptspect/pull/65) 的 hardening，到 [#78](https://github.com/Tom409114/scriptspect/pull/78) 的首页/发布证据升级、[#79](https://github.com/Tom409114/scriptspect/pull/79) 的 CodeQL 修复与 [#80](https://github.com/Tom409114/scriptspect/pull/80) 的终审闭环
+- 本次核验时保持开放的 release-please 候选：[PR #66](https://github.com/Tom409114/scriptspect/pull/66) at `bdc8e1990096db8ca096a8462e3307322d7c9f65`
+- README/status 固定的已审阅 runtime/Action evidence source：`c9c671c8e150705d78d9169d4c5a8f22cb37fad0`
 - 设计依据：[v0.1 hardening design](../superpowers/specs/2026-09-01-scriptspect-v0.1-hardening-design.md)
 - 历史基线：[spec compliance baseline](spec-compliance-2026-09-01.md)
 
@@ -38,8 +38,8 @@
 
 | 门禁 | 状态 | 当前事实 |
 |---|---|---|
-| 仓库内 correctness/security/docs 实现 | `LOCAL PASS / HOSTED PASS` | target-aware parser、严格配置/schema、root containment、事务型 fixer、bundled Action、双语生成式 demo 与可恢复 release workflows 已合并；`main` run [`33476006926`](https://github.com/Tom409114/scriptspect/actions/runs/33476006926) 在 `50d02d44abdbfb3489516f39f4251481dfec1548` 上 success。 |
-| release-please 候选 CI | `ACTION REQUIRED / PR OPEN` | PR #66 当前 head `390d7ccd61c79bedee182557bf4b6dc2bfbc7376` 的 run [`33476042317`](https://github.com/Tom409114/scriptspect/actions/runs/33476042317) 为 `action_required` 且没有 jobs；需按 `manual-approval` 策略批准后在该准确 head 重跑。旧 head 的 green run 只保留为历史快照。 |
+| 仓库内 correctness/security/docs 实现 | `LOCAL PASS / HOSTED PASS` | target-aware parser、严格配置/schema、root containment、事务型 fixer、bundled Action、双语生成式 demo 与可恢复 release workflows 已合并；`main` run [`33482453059`](https://github.com/Tom409114/scriptspect/actions/runs/33482453059) 在 `c9c671c8e150705d78d9169d4c5a8f22cb37fad0` 上 success。 |
+| release-please 候选 CI | `ACTION REQUIRED / PR OPEN` | PR #66 当前 head `bdc8e1990096db8ca096a8462e3307322d7c9f65` 的 run [`33482502821`](https://github.com/Tom409114/scriptspect/actions/runs/33482502821) 为 `action_required` 且没有 jobs；需按 `manual-approval` 策略批准后在该准确 head 重跑。旧 head 的 green run 只保留为历史快照。 |
 | 仓库与 tag 保护 | `ADMIN PARTIAL` | `main` ruleset `21964571` 与 semantic-version tag no-update/delete ruleset `21964642` 均 active；`npm-bootstrap`、`release` environments 及 owner approval 已建立。semantic tag 创建限制、floating `v0`/`v0.*` policy 与 coordinator bypass/permission drill 仍 OPEN。 |
 | npm bootstrap 与 Trusted Publishing | `ADMIN OPEN` | 五个仓库变量处于安全关闭态；npm 包仍需用独立 bootstrap prerelease 建立所有权和完整性契约，再配置并公开验证 OIDC。 |
 | v0.1.0 正式发布 | `PUBLICATION OPEN` | 尚无经过本管线验证的 npm `0.1.0`、GitHub Release、checksum、provenance 或 Action tags。 |
@@ -163,3 +163,13 @@ PR #78/#79 后的深度终审又定位并在当前候选中修复两项仓库内
 当前状态可以表述为：**“v0.1 hardening、双语首页与安全跟进已合并到 `main`，准确实现快照有 successful hosted CI；release PR #66 当前 head 仍等待人工 workflow approval 与 required CI。仓库保护已部分落地，仍等待 tag creation/floating coordinator 权限、npm bootstrap/OIDC、准确 release-merge SHA、真实公开发布与 M8 外部验收。”**
 
 当前状态不得表述为：**“release ready”“v0.1 已发布”“OIDC 已配置”“Action `@v0.1` 可用”“M0–M8 全部完成”或“已有外部采用”。**
+
+## 终审修复远程核签（2026-09-01，追加）
+
+- [PR #80](https://github.com/Tom409114/scriptspect/pull/80) 已合并为 `c9c671c8e150705d78d9169d4c5a8f22cb37fad0`；PR 的 required checks 全绿，准确 merge-SHA 的 [push CI run `33482453059`](https://github.com/Tom409114/scriptspect/actions/runs/33482453059) completed/success。
+- 该 run 覆盖三 OS × Node 22/24、90% parser/rule coverage、packed consumer、真实 bundled Action consumer/annotations、100-package benchmark、CodeQL 与生成物校验。合并前完整本地回归为 `69 files / 1,074 passed / 8 skipped`。
+- 因此前一节的 workspace containment、Action root boundary、corpus 1–1,000 source contract 与组合回归已从 `HOSTED PENDING` 升级为 `HOSTED PASS`。月度 collector 的源码与 workflow contract 同样 hosted-pass，但首次真实 scheduled draft 与人工复核仍 OPEN；1,000-repository 能力也不等于已执行一次 1,000-repository scan。
+- README 的预发布 source/Action 证据固定到该 exact main commit 与 run；这使首页示例可复制且可审计，但不创建不存在的 npm package 或 Action tag。
+- release-please [PR #66](https://github.com/Tom409114/scriptspect/pull/66) 已前进到 `bdc8e1990096db8ca096a8462e3307322d7c9f65`，其 run [`33482502821`](https://github.com/Tom409114/scriptspect/actions/runs/33482502821) 仍为 `action_required`。npm bootstrap/OIDC、tag policy、首次 release 与 M8 外部/时间证据继续保持原有 OPEN 状态。
+
+最终核签仍为 **`NOT RELEASE READY`**；仓库内本轮已确认的 correctness/security/docs 高中优先级问题已经闭环，但管理员、公开发布与真实外部采用门不能由代码代替。

--- a/tests/docs/readme-homepage.test.ts
+++ b/tests/docs/readme-homepage.test.ts
@@ -57,6 +57,23 @@ describe('bilingual homepage', () => {
     }
   });
 
+  it('answers what the product does, who uses it, and how it works', () => {
+    const english = read('README.md');
+    const chinese = read('README.zh-CN.md');
+
+    expect(english).toContain('## What it does, who it is for, and how it works');
+    expect(english).toContain('JS/TS maintainers');
+    expect(english).toContain('repository → static target-shell analysis');
+    expect(chinese).toContain('## 它到底做什么、谁适合用、怎么工作');
+    expect(chinese).toContain('JS/TS 维护者');
+    expect(chinese).toContain('repository → target-shell 静态分析');
+    for (const homepage of [english, chinese]) {
+      expect(homepage.indexOf('<!-- readme-section: purpose -->')).toBeLessThan(
+        homepage.indexOf('<!-- readme-section: demo -->'),
+      );
+    }
+  });
+
   it('presents only commands supported by the recorded release state', () => {
     const english = read('README.md');
     const chinese = read('README.zh-CN.md');
@@ -96,16 +113,16 @@ describe('bilingual homepage', () => {
       annotations: Array<{ title: string; displayTitle?: string; message: string }>;
     };
 
-    expect(evidence.sourceCommit).toBe('bf37b4132508c685a91cc16a9c0a3058c252502e');
+    expect(evidence.sourceCommit).toBe('c9c671c8e150705d78d9169d4c5a8f22cb37fad0');
     expect(evidence.workflowRun).toEqual(
       expect.objectContaining({
-        id: 33467290054,
+        id: 33482453059,
         conclusion: 'success',
-        url: 'https://github.com/Tom409114/scriptspect/actions/runs/33467290054',
+        url: 'https://github.com/Tom409114/scriptspect/actions/runs/33482453059',
       }),
     );
     expect(evidence.checkRun).toEqual(
-      expect.objectContaining({ id: 99729679961, annotationCount: 2 }),
+      expect.objectContaining({ id: 99774890433, annotationCount: 2 }),
     );
     expect(evidence.cleanConsumer).toEqual(
       expect.objectContaining({ exitCode: 0, packages: 1, scripts: 1, errors: 0 }),
@@ -133,8 +150,8 @@ describe('bilingual homepage', () => {
       expect(homepage).toContain('docs/assets/demo/action.txt');
       expect(homepage).toContain('docs/validation/readme-action-evidence.json');
       expect(homepage).toContain(evidence.workflowRun.url);
-      expect(homepage).toContain('33467290054');
-      expect(homepage).toContain('bf37b413');
+      expect(homepage).toContain('33482453059');
+      expect(homepage).toContain('c9c671c8');
     }
   });
 
@@ -395,14 +412,14 @@ describe('README demo artifacts', () => {
     expect(renderedColumnCounts.length).toBeGreaterThan(terminal.split('\n').length);
     expect(Math.max(...renderedColumnCounts)).toBeLessThanOrEqual(104);
     const actionText = read('docs/assets/demo/action.txt');
-    expect(actionText).toContain('workflow run: 33467290054 (success)');
-    expect(actionText).toContain('source commit: bf37b4132508c685a91cc16a9c0a3058c252502e');
+    expect(actionText).toContain('workflow run: 33482453059 (success)');
+    expect(actionText).toContain('source commit: c9c671c8e150705d78d9169d4c5a8f22cb37fad0');
     expect(actionText).toContain('broken fixture: 2 annotations');
     expect(actionText).toContain('PS010: scripts.clean');
     const actionSvg = read('docs/assets/demo/action.svg');
     expect(actionSvg).toMatch(/<svg[^>]+role="img"[^>]+aria-labelledby=/);
     expect(actionSvg).toContain('Hosted Action evidence');
-    expect(actionSvg).toContain('data-run-id="33467290054"');
+    expect(actionSvg).toContain('data-run-id="33482453059"');
     expect(actionSvg).not.toMatch(/<script|(?:href|src)=["']https?:\/\//iu);
     const patch = read('docs/assets/demo/fix.patch');
     expect(patch).toContain('--- a/package.json');


### PR DESCRIPTION
## What changed

- rewrites the English and Chinese homepage opening so it directly explains what ScriptSpect does, who uses it, what cross-platform script failures it catches, and how findings become a reviewable fix plan
- keeps the real before / result / patch / after demo prominent
- refreshes the README Action proof to the exact successful main run at c9c671c8
- updates the roadmap, compliance ledger, and v0.1 DoD with the merged PR #80 evidence while keeping external release gates open and honest

## Verification

- full suite already passed on this branch state: 69 files, 1,075 passed, 8 skipped
- README/public-claims tests: 16 passed
- TypeScript typecheck passed
- README parity and generated evidence checks passed
- changed-file Biome and git diff checks passed
- runtime/package/action source paths are unchanged from main