### PR TITLE
fix(release): accept the CLI version banner in bootstrap checks

### DIFF
--- a/.github/workflows/npm-bootstrap.yml
+++ b/.github/workflows/npm-bootstrap.yml
@@ -252,7 +252,7 @@ jobs:
           mkdir -p "$INSTALL_ROOT" "$FIXTURE"
           npm init -y --prefix "$INSTALL_ROOT" >/dev/null
           npm install --prefix "$INSTALL_ROOT" "$TARBALL" --ignore-scripts
-          [[ "$(node "$INSTALL_ROOT/node_modules/scriptspect/dist/cli.mjs" --version)" == "$VERSION" ]]
+          [[ "$(node "$INSTALL_ROOT/node_modules/scriptspect/dist/cli.mjs" --version)" == "scriptspect/$VERSION "* ]]
           test -f "$INSTALL_ROOT/node_modules/scriptspect/schema/config.schema.json"
           test -f "$INSTALL_ROOT/node_modules/scriptspect/schema/output.schema.json"
           test -f "$INSTALL_ROOT/node_modules/scriptspect/dist/action.mjs"
@@ -584,7 +584,7 @@ jobs:
           mkdir -p "$INSTALL_ROOT" "$FIXTURE"
           npm init -y --prefix "$INSTALL_ROOT" >/dev/null
           npm install --prefix "$INSTALL_ROOT" "$TARBALL" --ignore-scripts
-          [[ "$(node "$INSTALL_ROOT/node_modules/scriptspect/dist/cli.mjs" --version)" == "$VERSION" ]]
+          [[ "$(node "$INSTALL_ROOT/node_modules/scriptspect/dist/cli.mjs" --version)" == "scriptspect/$VERSION "* ]]
           test -f "$INSTALL_ROOT/node_modules/scriptspect/schema/config.schema.json"
           test -f "$INSTALL_ROOT/node_modules/scriptspect/schema/output.schema.json"
           test -f "$INSTALL_ROOT/node_modules/scriptspect/dist/action.mjs"
@@ -677,7 +677,7 @@ jobs:
           npm init -y --prefix "$INSTALL_ROOT" >/dev/null
           npm install --prefix "$INSTALL_ROOT" "scriptspect@$VERSION" --ignore-scripts
           npm audit signatures --prefix "$INSTALL_ROOT" --json > "$RUNNER_TEMP/bootstrap/audit-signatures.json"
-          [[ "$(node "$INSTALL_ROOT/node_modules/scriptspect/dist/cli.mjs" --version)" == "$VERSION" ]]
+          [[ "$(node "$INSTALL_ROOT/node_modules/scriptspect/dist/cli.mjs" --version)" == "scriptspect/$VERSION "* ]]
           test -f "$INSTALL_ROOT/node_modules/scriptspect/schema/config.schema.json"
           test -f "$INSTALL_ROOT/node_modules/scriptspect/schema/output.schema.json"
           test -f "$INSTALL_ROOT/node_modules/scriptspect/dist/action.mjs"

--- a/tests/release/bootstrap-cli-version.test.ts
+++ b/tests/release/bootstrap-cli-version.test.ts
@@ -22,7 +22,7 @@ it('bootstrap version gates accept the real CLI banner and reject a different ve
   for (const assertion of assertions) {
     const command = assertion.replace(
       '$INSTALL_ROOT/node_modules/scriptspect/dist/cli.mjs',
-      resolve('dist/cli.mjs').replaceAll('\\', '/'),
+      '$CLI_PATH',
     );
     for (const [expectedVersion, expectedStatus] of [
       [version, 0],
@@ -30,7 +30,11 @@ it('bootstrap version gates accept the real CLI banner and reject a different ve
     ] as const) {
       const result = spawnSync(bash, ['-c', command], {
         encoding: 'utf8',
-        env: { ...process.env, VERSION: expectedVersion },
+        env: {
+          ...process.env,
+          VERSION: expectedVersion,
+          CLI_PATH: resolve('dist/cli.mjs').replaceAll('\\', '/'),
+        },
       });
       expect(result.error).toBeUndefined();
       expect(result.status, result.stderr).toBe(expectedStatus);

--- a/tests/release/bootstrap-cli-version.test.ts
+++ b/tests/release/bootstrap-cli-version.test.ts
@@ -10,7 +10,7 @@ const bash =
   process.platform === 'win32'
     ? resolve(
         dirname(
-          spawnSync('where.exe', ['git'], { encoding: 'utf8' }).stdout.trim().split(/\r?\n/)[0],
+          spawnSync('where.exe', ['git'], { encoding: 'utf8' }).stdout.trim().split(/\r?\n/)[0] ?? '',
         ),
         '../bin/bash.exe',
       )

--- a/tests/release/bootstrap-cli-version.test.ts
+++ b/tests/release/bootstrap-cli-version.test.ts
@@ -1,0 +1,38 @@
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { expect, it } from 'vitest';
+
+const workflow = readFileSync('.github/workflows/npm-bootstrap.yml', 'utf8');
+const assertions = workflow.split('\n').filter((line) => line.includes('--version)" =='));
+const version = JSON.parse(readFileSync('package.json', 'utf8')).version;
+const bash =
+  process.platform === 'win32'
+    ? resolve(
+        dirname(
+          spawnSync('where.exe', ['git'], { encoding: 'utf8' }).stdout.trim().split(/\r?\n/)[0],
+        ),
+        '../bin/bash.exe',
+      )
+    : 'bash';
+
+it('bootstrap version gates accept the real CLI banner and reject a different version', () => {
+  expect(assertions).toHaveLength(3);
+  for (const assertion of assertions) {
+    const command = assertion.replace(
+      '$INSTALL_ROOT/node_modules/scriptspect/dist/cli.mjs',
+      resolve('dist/cli.mjs').replaceAll('\\', '/'),
+    );
+    for (const [expectedVersion, expectedStatus] of [
+      [version, 0],
+      ['99.99.99-wrong', 1],
+    ] as const) {
+      const result = spawnSync(bash, ['-c', command], {
+        encoding: 'utf8',
+        env: { ...process.env, VERSION: expectedVersion },
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.status, result.stderr).toBe(expectedStatus);
+    }
+  }
+});

--- a/tests/release/bootstrap-cli-version.test.ts
+++ b/tests/release/bootstrap-cli-version.test.ts
@@ -10,7 +10,8 @@ const bash =
   process.platform === 'win32'
     ? resolve(
         dirname(
-          spawnSync('where.exe', ['git'], { encoding: 'utf8' }).stdout.trim().split(/\r?\n/)[0] ?? '',
+          spawnSync('where.exe', ['git'], { encoding: 'utf8' }).stdout.trim().split(/\r?\n/)[0] ??
+            '',
         ),
         '../bin/bash.exe',
       )


### PR DESCRIPTION
Fixes the first bootstrap run (34021203019), which installed successfully but compared CAC's full version banner against a bare version. All three bootstrap gates now match the exact scriptspect/version token, including the following space delimiter. Adds a behavioral regression test that executes the workflow assertions against the real built CLI and rejects an incorrect version. Verified red before fix and green after fix; 99 release tests pass. No npm version was published by the failed run.