### PR TITLE
fix(release): handle npm's initial latest assignment

### DIFF
--- a/.github/workflows/npm-bootstrap.yml
+++ b/.github/workflows/npm-bootstrap.yml
@@ -695,6 +695,7 @@ jobs:
           test -s "$RUNNER_TEMP/bootstrap/registry-action-summary"
 
           jq -n \
+            --slurpfile registryState "$RUNNER_TEMP/bootstrap/verified-registry-state.json" \
             --arg version "$VERSION" \
             --arg sourceCommit "$SOURCE_SHA" \
             --arg mode "$MODE" \
@@ -710,7 +711,7 @@ jobs:
               registryIntegrity: $registryIntegrity,
               comparatorAlgorithm: "scriptspect-canonical-tree/v1",
               comparatorAlgorithmDigest: $comparatorAlgorithmDigest,
-              latestUnchanged: true,
+              latestUnchanged: ($registryState[0].latestBefore == $registryState[0].latestAfter),
               workflowRunUrl: $workflowRunUrl,
               nextRequiredActions: [
                 "Review and commit this file as docs/release/npm-integrity-contract.json with reviewedAt added",
@@ -718,7 +719,9 @@ jobs:
                 "Revoke the granular npm token and remove NPM_BOOTSTRAP_TOKEN",
                 "Set NPM_BOOTSTRAP_ENABLED to false before formal publication"
               ]
-            }' > "$RUNNER_TEMP/bootstrap/bootstrap-integrity-contract.json"
+            } + (if $registryState[0].initialLatestAssignment then
+              {initialLatestAssignment: $registryState[0].initialLatestAssignment}
+              else {} end)' > "$RUNNER_TEMP/bootstrap/bootstrap-integrity-contract.json"
       - name: Retain bootstrap evidence for maintainer review
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/npm-bootstrap.yml
+++ b/.github/workflows/npm-bootstrap.yml
@@ -532,7 +532,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.source-sha }}
+          # Use the reviewed verifier from this workflow revision when recovering
+          # an already-published candidate; SOURCE_SHA still binds its artifact.
+          ref: ${{ github.sha }}
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/tests/release/npm-bootstrap-state.test.ts
+++ b/tests/release/npm-bootstrap-state.test.ts
@@ -255,6 +255,25 @@ describe('npm bootstrap registry state verifier', () => {
     }
   });
 
+  it('accepts only the exact initial latest assignment observed on npm', () => {
+    const result = verify({
+      owners: ['Tom409114 <tom@example.test>'],
+      before: {},
+      after: { bootstrap: '0.0.0-bootstrap.0', latest: '0.0.0-bootstrap.0' },
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout).latestAfter).toBe('0.0.0-bootstrap.0');
+    for (const before of [{ latest: '1.2.3' }, { next: '1.2.3' }]) {
+      expect(
+        verify({
+          owners: ['Tom409114 <tom@example.test>'],
+          before,
+          after: { bootstrap: '0.0.0-bootstrap.0', latest: '0.0.0-bootstrap.0' },
+        }).status,
+      ).not.toBe(0);
+    }
+  });
+
   it('rejects any additional maintainer after case-insensitive deduplication', () => {
     const result = verify({
       owners: [

--- a/tests/release/release-contract.test.ts
+++ b/tests/release/release-contract.test.ts
@@ -94,6 +94,42 @@ function integrityContract(mode: IntegrityMode, comparatorDigest = canonicalTree
   };
 }
 
+it('verifies initial registry latest assignment without claiming latest stayed unchanged', () => {
+  const { candidate, exactRegistry } = integrityTarballs('initial-latest');
+  const contract = {
+    ...integrityContract('exact-bytes'),
+    latestUnchanged: false,
+    initialLatestAssignment: {
+      before: {},
+      after: {
+        bootstrap: '0.0.0-bootstrap.0',
+        latest: '0.0.0-bootstrap.0',
+      },
+    },
+  };
+  const accepted = runIntegrityVerifier(contract, candidate, exactRegistry);
+  expect(accepted.status, accepted.stderr).toBe(0);
+  for (const invalid of [
+    { ...contract, initialLatestAssignment: undefined },
+    {
+      ...contract,
+      initialLatestAssignment: {
+        before: { latest: '1.0.0' },
+        after: contract.initialLatestAssignment.after,
+      },
+    },
+    {
+      ...contract,
+      initialLatestAssignment: {
+        before: {},
+        after: { bootstrap: '0.0.0-bootstrap.0', latest: '0.0.0-bootstrap.1' },
+      },
+    },
+    { ...contract, latestUnchanged: true },
+  ])
+    expect(runIntegrityVerifier(invalid, candidate, exactRegistry).status).not.toBe(0);
+});
+
 function npmSri(path: string): string {
   return `sha512-${createHash('sha512').update(readFileSync(path)).digest('base64')}`;
 }

--- a/tools/release/verify-npm-bootstrap-state.mjs
+++ b/tools/release/verify-npm-bootstrap-state.mjs
@@ -144,7 +144,13 @@ if (options.before === undefined) {
   }
   const latestBefore = before.latest ?? null;
   const latestAfter = after.latest ?? null;
-  if (latestBefore !== latestAfter) fail('latest dist-tag changed during bootstrap');
+  const initialLatestAssignment =
+    Object.keys(before).length === 0 &&
+    Object.keys(after).length === 2 &&
+    latestAfter === options.version;
+  if (latestBefore !== latestAfter && !initialLatestAssignment) {
+    fail('latest dist-tag changed during bootstrap');
+  }
 
   console.log(
     JSON.stringify({
@@ -153,6 +159,7 @@ if (options.before === undefined) {
       latestBefore,
       latestAfter,
       bootstrap: after.bootstrap,
+      ...(initialLatestAssignment ? { initialLatestAssignment: { before, after } } : {}),
     }),
   );
 }

--- a/tools/release/verify-package-integrity.mjs
+++ b/tools/release/verify-package-integrity.mjs
@@ -38,7 +38,7 @@ export function verifyIntegrityContract(value) {
       'workflowRunUrl',
       'reviewedAt',
     ],
-    ['nextRequiredActions'],
+    ['nextRequiredActions', 'initialLatestAssignment'],
   );
   if (contract.schemaVersion !== 1) {
     throw new ReleaseToolError('npm integrity contract schemaVersion must be 1');
@@ -64,7 +64,25 @@ export function verifyIntegrityContract(value) {
       'npm integrity contract comparator algorithm digest does not match the executable comparator',
     );
   }
-  if (contract.latestUnchanged !== true) {
+  if (contract.initialLatestAssignment !== undefined) {
+    const initial = requireExactKeys(
+      contract.initialLatestAssignment,
+      'initial latest assignment',
+      ['before', 'after'],
+    );
+    requireExactKeys(initial.before, 'initial dist-tags before', []);
+    const after = requireExactKeys(initial.after, 'initial dist-tags after', [
+      'bootstrap',
+      'latest',
+    ]);
+    if (
+      contract.latestUnchanged !== false ||
+      after.bootstrap !== contract.bootstrapVersion ||
+      after.latest !== contract.bootstrapVersion
+    ) {
+      throw new ReleaseToolError('invalid initial latest assignment');
+    }
+  } else if (contract.latestUnchanged !== true) {
     throw new ReleaseToolError('npm integrity contract latestUnchanged must be true');
   }
   if (contract.nextRequiredActions !== undefined) {
@@ -101,7 +119,12 @@ export function verifyIntegrityContract(value) {
       'npm integrity contract reviewedAt',
       /^[0-9]{4}-[0-9]{2}-[0-9]{2}T/u,
     ),
-    latestUnchanged: true,
+    latestUnchanged: contract.latestUnchanged,
+    ...(contract.initialLatestAssignment === undefined
+      ? {}
+      : {
+          initialLatestAssignment: contract.initialLatestAssignment,
+        }),
     ...(contract.nextRequiredActions === undefined
       ? {}
       : { nextRequiredActions: contract.nextRequiredActions }),


### PR DESCRIPTION
Bootstrap run 34021829665 published successfully, but npm also assigned latest to the first version despite --tag bootstrap. Authenticated removal returned HTTP 400. Accept only empty before-tags and exactly bootstrap/latest pointing at the requested bootstrap version; existing latest moves remain rejected. Persist before/after evidence and latestUnchanged=false in the integrity contract. Added red/green behavioral tests, 101 release tests and typecheck pass. No new publication requested by this PR.