### PR TITLE
fix(ci): authenticate release candidate intent lookup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -400,6 +400,7 @@ jobs:
       - name: Pack once and create the versioned candidate manifest
         if: steps.recover.outputs.needs-build == 'true'
         env:
+          GH_TOKEN: ${{ github.token }}
           SHA: ${{ needs.authorize.outputs.sha }}
           VERSION: ${{ needs.authorize.outputs.version }}
           TAG: ${{ needs.authorize.outputs.tag }}

--- a/tests/release/workflow-auth.test.ts
+++ b/tests/release/workflow-auth.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+type Environment = Record<string, string>;
+type Workflow = {
+  env?: Environment;
+  jobs: Record<
+    string,
+    {
+      env?: Environment;
+      steps: { name?: string; env?: Environment; run?: string }[];
+    }
+  >;
+};
+
+it('supplies workflow authentication at every release GitHub CLI boundary', () => {
+  for (const file of ['release.yml', 'npm-publish.yml', 'npm-bootstrap.yml']) {
+    const workflow = parse(readFileSync(`.github/workflows/${file}`, 'utf8')) as Workflow;
+    for (const [jobName, job] of Object.entries(workflow.jobs)) {
+      for (const step of job.steps) {
+        if (!/\bgh (?:api|release|run)\b/.test(step.run ?? '')) continue;
+        const environment = { ...workflow.env, ...job.env, ...step.env };
+        expect(
+          environment.GH_TOKEN || environment.GITHUB_TOKEN,
+          `${file}: ${jobName}: ${step.name}`,
+        ).toBeTruthy();
+      }
+    }
+  }
+});


### PR DESCRIPTION
Fixes the missing GH_TOKEN in candidate packing, observed in formal release run 34132563361. Adds a workflow authentication-boundary regression test (red before fix, green after). All 102 release tests pass after rebuilding the current version. Recovery will dispatch the corrected coordinator for the original 0.1.0 source commit; package contents stay unchanged.