### PR TITLE
fix(ci): allow authorized manual release recovery jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,6 +326,7 @@ jobs:
   build-candidate:
     name: Build or recover the externally anchored candidate
     needs: [authorize]
+    if: always() && needs.authorize.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:
@@ -526,6 +527,7 @@ jobs:
   stage-release:
     name: Recover or stage the protected tag and authoritative draft
     needs: [authorize, build-candidate]
+    if: always() && needs.authorize.result == 'success' && needs.build-candidate.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: release
@@ -805,7 +807,7 @@ jobs:
   dispatch-publisher:
     name: Dispatch the exact immutable-tag publisher
     needs: [authorize, stage-release]
-    if: needs.stage-release.result == 'success'
+    if: always() && needs.authorize.result == 'success' && needs.stage-release.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: release

--- a/tests/release/publisher-dispatch.test.ts
+++ b/tests/release/publisher-dispatch.test.ts
@@ -287,7 +287,7 @@ describe('release publisher dispatch workflow', () => {
 
     expect(dispatch).toBeDefined();
     expect(dispatch?.needs).toEqual(['authorize', 'stage-release']);
-    expect(dispatch?.if).toBe("needs.stage-release.result == 'success'");
+    expect(dispatch?.if).toContain("needs.stage-release.result == 'success'");
     expect(dispatch?.environment).toBe('release');
     expect(dispatch?.['timeout-minutes']).toBeGreaterThan(0);
     expect(dispatch?.permissions).toEqual({

--- a/tests/release/recovery-job-gates.test.ts
+++ b/tests/release/recovery-job-gates.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+const workflow = parse(readFileSync('.github/workflows/release.yml', 'utf8'));
+
+it('keeps recovery downstream jobs eligible after discovery is intentionally skipped', () => {
+  for (const jobName of ['build-candidate', 'stage-release', 'dispatch-publisher']) {
+    const job = workflow.jobs[jobName];
+    // A status function disables Actions implicit success() across skipped ancestors.
+    expect(job.if, jobName).toMatch(/always\(\)/);
+    for (const dependency of job.needs) {
+      expect(job.if, `${jobName} must still fail closed on ${dependency}`).toContain(
+        `needs.${dependency}.result == 'success'`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
Manual recovery run 34133310146 authorized correctly but downstream jobs inherited the intentionally skipped discovery ancestor. Add explicit status guards while requiring each direct dependency to succeed. Regression gate catches missing recovery conditions; all 103 release tests pass. No package-content changes.