### PR TITLE
fix(ci): use scoped deploy key for protected release tags

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -377,6 +377,8 @@ jobs:
         with:
           ref: ${{ needs.publish.outputs.sha }}
           fetch-depth: 0
+          ssh-key: ${{ secrets.RELEASE_TAG_DEPLOY_KEY }}
+          persist-credentials: true
       - name: Apply semver and ancestry guards, then update aliases by CAS
         id: aliases
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -547,7 +547,8 @@ jobs:
         with:
           ref: ${{ needs.authorize.outputs.sha }}
           fetch-depth: 0
-          persist-credentials: false
+          ssh-key: ${{ secrets.RELEASE_TAG_DEPLOY_KEY }}
+          persist-credentials: true
       - name: Download the retained candidate from its durable artifact anchor
         env:
           GH_TOKEN: ${{ github.token }}
@@ -598,21 +599,9 @@ jobs:
           CANDIDATE_DIGEST=$(node tools/release/release-state.mjs json-digest \
             "$RUNNER_TEMP/candidate/candidate-manifest.json" | jq -er '.digest')
           CURRENT_STATE=$(jq -er '.state' "$RUNNER_TEMP/release-state.json")
-          jq -n --arg ref "refs/tags/$TAG" --arg sha "$SHA" '{ref:$ref,sha:$sha}' \
-            > "$RUNNER_TEMP/create-tag.json"
-          HTTP_STATUS=$(curl --silent --show-error --output "$RUNNER_TEMP/create-tag-response.json" \
-            --write-out '%{http_code}' --request POST \
-            --header "Authorization: Bearer $GH_TOKEN" \
-            --header 'Accept: application/vnd.github+json' \
-            --header 'X-GitHub-Api-Version: 2022-11-28' \
-            --data-binary @"$RUNNER_TEMP/create-tag.json" \
-            "https://api.github.com/repos/$REPOSITORY/git/refs")
-          if [[ "$HTTP_STATUS" == 201 ]]; then
-            [[ "$CURRENT_STATE" == retained-candidate ]]
-          elif [[ "$HTTP_STATUS" != 422 ]]; then
-            cat "$RUNNER_TEMP/create-tag-response.json" >&2
-            exit 1
-          fi
+          # The protected tag creation rule authorizes only the release deploy key.
+          # No force: an existing tag at another commit must fail closed.
+          git push origin "$SHA:refs/tags/$TAG"
           gh api -H 'Accept: application/vnd.github+json' \
             "repos/$REPOSITORY/git/ref/tags/$TAG" > "$RUNNER_TEMP/tag-ref.json"
           jq -e --arg ref "refs/tags/$TAG" --arg sha "$SHA" \

--- a/tests/release/release-contract.test.ts
+++ b/tests/release/release-contract.test.ts
@@ -897,15 +897,12 @@ describe('release coordinator trust and recovery', () => {
     });
   });
 
-  it('creates the immutable tag through the create-only refs API and verifies 422 retries', () => {
+  it('creates the immutable tag without force and verifies its exact remote commit', () => {
     const stage = jobSource('release.yml', 'stage-release');
-    expect(stage).toContain('git/refs');
-    expect(stage).toContain('refs/tags/$TAG');
-    expect(stage).toContain('HTTP_STATUS');
-    expect(stage).toContain('422');
+    expect(stage).toContain('git push origin "$SHA:refs/tags/$TAG"');
     expect(stage).toContain('git/ref/tags/$TAG');
     expect(stage).toContain('object.sha == $sha');
-    expect(stage).not.toContain('git push');
+    expect(stage).not.toContain('--force');
   });
 
   it('runs trusted publication only from the exact immutable tag event context', () => {

--- a/tests/release/tag-credentials.test.ts
+++ b/tests/release/tag-credentials.test.ts
@@ -6,7 +6,7 @@ it('uses the release-scoped deploy key for both protected tag writers', () => {
   for (const [file, jobName] of [
     ['release.yml', 'stage-release'],
     ['npm-publish.yml', 'advance-aliases'],
-  ]) {
+  ] as const) {
     const workflow = parse(readFileSync(`.github/workflows/${file}`, 'utf8'));
     const job = workflow.jobs[jobName];
     expect(job.environment).toBe('release');

--- a/tests/release/tag-credentials.test.ts
+++ b/tests/release/tag-credentials.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+it('uses the release-scoped deploy key for both protected tag writers', () => {
+  for (const [file, jobName] of [
+    ['release.yml', 'stage-release'],
+    ['npm-publish.yml', 'advance-aliases'],
+  ]) {
+    const workflow = parse(readFileSync(`.github/workflows/${file}`, 'utf8'));
+    const job = workflow.jobs[jobName];
+    expect(job.environment).toBe('release');
+    const checkout = job.steps.find((step: { uses?: string }) =>
+      step.uses?.startsWith('actions/checkout@'),
+    );
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: GitHub Actions expression
+    expect(checkout.with['ssh-key']).toBe('${{ secrets.RELEASE_TAG_DEPLOY_KEY }}');
+    expect(checkout.with['persist-credentials']).not.toBe(false);
+  }
+});


### PR DESCRIPTION
Minimal alignment with existing tag protection: use the existing release environment deploy key for immutable tag creation and guarded alias pushes. No ruleset changes or broader permissions. Immutable creation is non-force and verifies the remote target; existing alias CAS guards remain. 104 release tests passed. Supersedes the untagged 0.1.0 candidate so the new candidate includes both writer fixes.