### PR TITLE
fix(ci): read draft releases by id and prepare valid tag fixtures

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,8 +1,6 @@
 name: npm publish from immutable tag
 
 on:
-  push:
-    tags: ['v[0-9]+.[0-9]+.[0-9]+']
   workflow_dispatch:
     inputs:
       intent-id:
@@ -44,7 +42,7 @@ jobs:
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
           mkdir -p .ci/release-clean .ci/release-broken
-          node -e "require('node:fs').writeFileSync('.ci/release-clean/package.json', JSON.stringify({name:'clean',scripts:{build:'node -e \\"process.exit(0)\\"'}}, null, 2))"
+          node -e "require('node:fs').writeFileSync('.ci/release-clean/package.json', JSON.stringify({name:'clean',scripts:{build:'node --version'}}, null, 2))"
           node -e "require('node:fs').writeFileSync('.ci/release-broken/package.json', JSON.stringify({name:'broken',scripts:{clean:'rm -rf dist'}}, null, 2))"
       - name: Analyze broken fixture from the immutable tag
         id: broken
@@ -219,7 +217,7 @@ jobs:
             "$RUNNER_TEMP/release/release-manifest.json" \
             "$RUNNER_TEMP/release/candidate-manifest.json" >/dev/null
           RELEASE_JSON=$(gh api -H 'Accept: application/vnd.github+json' \
-            "repos/$REPOSITORY/releases/tags/$TAG")
+            "repos/$REPOSITORY/releases/$(gh release view "$TAG" --repo "$REPOSITORY" --json databaseId --jq .databaseId)")
           RELEASE_ID=$(jq -er '.id' <<< "$RELEASE_JSON")
           RELEASE_DRAFT=$(jq -r '.draft | if type == "boolean" then tostring else error("draft is not boolean") end' <<< "$RELEASE_JSON")
           ACTUAL_RELEASE_ASSET_COUNT=$(jq '.assets | length' <<< "$RELEASE_JSON")
@@ -495,7 +493,7 @@ jobs:
 
           # Fail closed on any late Contents-write drift immediately before publication.
           gh api -H 'Accept: application/vnd.github+json' \
-            "repos/$REPOSITORY/releases/tags/$TAG" > "$RUNNER_TEMP/pre-public-release.json"
+            "repos/$REPOSITORY/releases/$(gh release view "$TAG" --repo "$REPOSITORY" --json databaseId --jq .databaseId)" > "$RUNNER_TEMP/pre-public-release.json"
           gh api -H 'Accept: application/vnd.github+json' \
             "repos/$REPOSITORY/git/ref/tags/$TAG" > "$RUNNER_TEMP/pre-public-tag.json"
           jq '[
@@ -522,7 +520,7 @@ jobs:
             [[ "$PRE_PUBLIC_DRAFT" == false ]]
           fi
           gh api -H 'Accept: application/vnd.github+json' \
-            "repos/$REPOSITORY/releases/tags/$TAG" > "$RUNNER_TEMP/published-release.json"
+            "repos/$REPOSITORY/releases/$(gh release view "$TAG" --repo "$REPOSITORY" --json databaseId --jq .databaseId)" > "$RUNNER_TEMP/published-release.json"
           gh api -H 'Accept: application/vnd.github+json' \
             "repos/$REPOSITORY/git/ref/tags/$TAG" > "$RUNNER_TEMP/published-tag.json"
           jq '[
@@ -663,7 +661,7 @@ jobs:
             "repos/$REPOSITORY/check-runs/$INTENT_ID" --input "$RUNNER_TEMP/update-check.json" >/dev/null
 
           RELEASE_JSON=$(gh api -H 'Accept: application/vnd.github+json' \
-            "repos/$REPOSITORY/releases/tags/$TAG")
+            "repos/$REPOSITORY/releases/$(gh release view "$TAG" --repo "$REPOSITORY" --json databaseId --jq .databaseId)")
           FINAL_COUNT=$(jq '[.assets[] | select(.name == "final-verification.json")] | length' <<< "$RELEASE_JSON")
           [[ "$FINAL_COUNT" -le 1 ]]
           if [[ "$FINAL_COUNT" == 1 ]]; then
@@ -685,7 +683,7 @@ jobs:
 
           for attempt in {1..12}; do
             RELEASE_JSON=$(gh api -H 'Accept: application/vnd.github+json' \
-              "repos/$REPOSITORY/releases/tags/$TAG")
+              "repos/$REPOSITORY/releases/$(gh release view "$TAG" --repo "$REPOSITORY" --json databaseId --jq .databaseId)")
             FINAL_COUNT=$(jq '[.assets[] | select(.name == "final-verification.json")] | length' \
               <<< "$RELEASE_JSON")
             [[ "$FINAL_COUNT" -le 1 ]]
@@ -713,7 +711,7 @@ jobs:
 
           # Verify the complete proposed terminal state before making consumed durable.
           RELEASE_JSON=$(gh api -H 'Accept: application/vnd.github+json' \
-            "repos/$REPOSITORY/releases/tags/$TAG")
+            "repos/$REPOSITORY/releases/$(gh release view "$TAG" --repo "$REPOSITORY" --json databaseId --jq .databaseId)")
           gh api -H 'Accept: application/vnd.github+json' \
             "repos/$REPOSITORY/git/ref/tags/$TAG" > "$RUNNER_TEMP/final-tag.json"
           printf '%s\n' "$RELEASE_JSON" > "$RUNNER_TEMP/final-release.json"
@@ -854,7 +852,7 @@ jobs:
           ROLLBACK_RELEASE_ID=$(jq -er '.stagedDraft.releaseId' "$RUNNER_TEMP/release-state.json")
           [[ "$ROLLBACK_SHA" == "$SHA" ]]
           RELEASE_JSON=$(gh api -H 'Accept: application/vnd.github+json' \
-            "repos/$REPOSITORY/releases/tags/$ROLLBACK_TAG")
+            "repos/$REPOSITORY/releases/$(gh release view "$ROLLBACK_TAG" --repo "$REPOSITORY" --json databaseId --jq .databaseId)")
           jq -e --argjson releaseId "$ROLLBACK_RELEASE_ID" --arg tag "$ROLLBACK_TAG" \
             '.id == $releaseId and .tag_name == $tag' <<< "$RELEASE_JSON" >/dev/null
           gh api -H 'Accept: application/vnd.github+json' \
@@ -890,7 +888,7 @@ jobs:
             gh api -X DELETE -H 'Accept: application/vnd.github+json' \
               "repos/$REPOSITORY/releases/assets/$FINAL_ASSET_ID"
             RELEASE_JSON=$(gh api -H 'Accept: application/vnd.github+json' \
-              "repos/$REPOSITORY/releases/tags/$ROLLBACK_TAG")
+              "repos/$REPOSITORY/releases/$(gh release view "$ROLLBACK_TAG" --repo "$REPOSITORY" --json databaseId --jq .databaseId)")
             jq -e --argjson releaseId "$ROLLBACK_RELEASE_ID" --arg tag "$ROLLBACK_TAG" \
               '.id == $releaseId and .tag_name == $tag' <<< "$RELEASE_JSON" >/dev/null
             gh api -H 'Accept: application/vnd.github+json' \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -618,7 +618,7 @@ jobs:
             test -s "$RUNNER_TEMP/release-notes.md" || printf 'ScriptSpect %s\n' "$VERSION" > "$RUNNER_TEMP/release-notes.md"
             gh release create "$TAG" --draft --verify-tag --title "$TAG" --notes-file "$RUNNER_TEMP/release-notes.md"
           fi
-          RELEASE_JSON=$(gh api -H 'Accept: application/vnd.github+json' "repos/$REPOSITORY/releases/tags/$TAG")
+          RELEASE_JSON=$(gh api -H 'Accept: application/vnd.github+json' "repos/$REPOSITORY/releases/$(gh release view "$TAG" --repo "$REPOSITORY" --json databaseId --jq .databaseId)")
           RELEASE_ID=$(jq -er '.id' <<< "$RELEASE_JSON")
           RELEASE_TAG=$(jq -er '.tag_name' <<< "$RELEASE_JSON")
           [[ "$RELEASE_TAG" == "$TAG" ]]
@@ -679,7 +679,7 @@ jobs:
             if [[ "$existing_count" == 0 ]]; then
               [[ "$CURRENT_STATE" == retained-candidate ]]
               gh release upload "$TAG" "$file"
-              RELEASE_JSON=$(gh api -H 'Accept: application/vnd.github+json' "repos/$REPOSITORY/releases/tags/$TAG")
+              RELEASE_JSON=$(gh api -H 'Accept: application/vnd.github+json' "repos/$REPOSITORY/releases/$(gh release view "$TAG" --repo "$REPOSITORY" --json databaseId --jq .databaseId)")
               return
             fi
             mkdir -p "$RUNNER_TEMP/existing-$name"
@@ -691,7 +691,7 @@ jobs:
           ensure_asset "$RUNNER_TEMP/candidate/SHA256SUMS"
           ensure_asset "$RUNNER_TEMP/candidate/candidate-manifest.json"
 
-          RELEASE_JSON=$(gh api -H 'Accept: application/vnd.github+json' "repos/$REPOSITORY/releases/tags/$TAG")
+          RELEASE_JSON=$(gh api -H 'Accept: application/vnd.github+json' "repos/$REPOSITORY/releases/$(gh release view "$TAG" --repo "$REPOSITORY" --json databaseId --jq .databaseId)")
           asset_id() {
             jq -er --arg name "$1" '[.assets[] | select(.name == $name)] | if length == 1 then .[0].id else error("asset cardinality") end' <<< "$RELEASE_JSON"
           }
@@ -747,7 +747,7 @@ jobs:
           RELEASE_MANIFEST_DIGEST=$(node tools/release/release-state.mjs json-digest \
             "$RUNNER_TEMP/candidate/release-manifest.json" | jq -er '.digest')
           for attempt in {1..12}; do
-            RELEASE_JSON=$(gh api -H 'Accept: application/vnd.github+json' "repos/$REPOSITORY/releases/tags/$TAG")
+            RELEASE_JSON=$(gh api -H 'Accept: application/vnd.github+json' "repos/$REPOSITORY/releases/$(gh release view "$TAG" --repo "$REPOSITORY" --json databaseId --jq .databaseId)")
             READY_COUNT=$(jq --arg tarball "$TARBALL" '[
               .assets[] | select(.name == $tarball or .name == "SHA256SUMS" or
                 .name == "candidate-manifest.json" or .name == "release-manifest.json") |

--- a/tests/release/release-contract.test.ts
+++ b/tests/release/release-contract.test.ts
@@ -907,7 +907,7 @@ describe('release coordinator trust and recovery', () => {
 
   it('runs trusted publication only from the exact immutable tag event context', () => {
     const publisher = workflow('npm-publish.yml');
-    expect(publisher.on).toMatchObject({ push: { tags: ['v[0-9]+.[0-9]+.[0-9]+'] } });
+    expect(publisher.on).not.toHaveProperty('push');
     expect(publisher.on).toHaveProperty('workflow_dispatch');
     expect(publisher.jobs?.publish?.environment).toBe('release');
     const run = jobSource('npm-publish.yml', 'publish');

--- a/tests/release/tag-fixtures.test.ts
+++ b/tests/release/tag-fixtures.test.ts
@@ -1,0 +1,61 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+it('executes the immutable-tag fixture preparation with valid shell quoting', () => {
+  const workflow = parse(readFileSync('.github/workflows/npm-publish.yml', 'utf8'));
+  const step = workflow.jobs['verify-action-tag'].steps.find(
+    (item: { name?: string }) => item.name === 'Prepare immutable-tag fixtures',
+  );
+  const directory = mkdtempSync(join(tmpdir(), 'scriptspect-tag-fixtures-'));
+  const bash =
+    process.platform === 'win32'
+      ? resolve(
+          dirname(
+            spawnSync('where.exe', ['git'], { encoding: 'utf8' }).stdout.trim().split(/\r?\n/)[0] ??
+              '',
+          ),
+          '../bin/bash.exe',
+        )
+      : 'bash';
+  try {
+    for (const args of [
+      ['init'],
+      [
+        '-c',
+        'user.name=Fixture',
+        '-c',
+        'user.email=fixture@example.invalid',
+        'commit',
+        '--allow-empty',
+        '-m',
+        'fixture',
+      ],
+    ]) {
+      expect(spawnSync('git', args, { cwd: directory }).status).toBe(0);
+    }
+    const sha = spawnSync('git', ['rev-parse', 'HEAD'], {
+      cwd: directory,
+      encoding: 'utf8',
+    }).stdout.trim();
+    const result = spawnSync(bash, ['-c', step.run], {
+      cwd: directory,
+      encoding: 'utf8',
+      env: { ...process.env, GITHUB_SHA: sha },
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(
+      JSON.parse(readFileSync(join(directory, '.ci/release-clean/package.json'), 'utf8')).scripts
+        .build,
+    ).toBe('node --version');
+    expect(
+      JSON.parse(readFileSync(join(directory, '.ci/release-broken/package.json'), 'utf8')).scripts
+        .clean,
+    ).toBe('rm -rf dist');
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes two observed release failures: draft releases require ID-based REST lookup, and immutable-tag clean fixture shell quoting was invalid. The fixture preparation now executes in a temporary real git repo in tests. Only the coordinator dispatch triggers publication after staging (no premature tag-push race). Live draft lookup, typecheck and 105 release tests pass. v0.1.0 remains an unpublished immutable draft; the corrected candidate will use 0.1.1.