### PR TITLE
fix(ci): grant publisher access to draft release assets

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -82,7 +82,8 @@ jobs:
     permissions:
       actions: read
       checks: write
-      contents: read
+      # GitHub hides draft releases and assets from read-only installation tokens.
+      contents: write
       id-token: write
       pull-requests: read
     outputs:

--- a/tests/release/release-contract.test.ts
+++ b/tests/release/release-contract.test.ts
@@ -891,7 +891,7 @@ describe('release coordinator trust and recovery', () => {
     expect(publish).toContain('--provenance');
     expect(publish).not.toContain('NPM_TOKEN');
     expect(workflow('npm-publish.yml').jobs?.publish?.permissions).toMatchObject({
-      contents: 'read',
+      contents: 'write',
       'id-token': 'write',
       checks: 'write',
     });


### PR DESCRIPTION
Minimal permission correction: the protected publish job needs contents: write for GitHub to expose draft releases/assets. The existing read-only token caused release not found before npm access in run 34137363694, while the draft and four assets exist (Release ID 384175717). No tag protection or npm authorization changes. Regression expectation updated; 105 release tests pass.